### PR TITLE
Change label of Party and Speaker dropdown to include "Alla" + Quick …

### DIFF
--- a/src/components/metaDataComponents/dropdownSelection.vue
+++ b/src/components/metaDataComponents/dropdownSelection.vue
@@ -7,7 +7,8 @@
     clearable
     v-model="store.selected[props.type]"
     :options="filterOptions"
-    :label="$t(`${props.type}`)"
+    :label="'Alla ' + $t(`${props.type}`)"
+    :placeholder="store.selected[props.type].length === 0 ? 'Välj specifika ' + $t(`${props.type}`) : ''"
     label-color="black"
     use-chips
     filled

--- a/src/components/metaDataComponents/genderOfficeToggleCheckbox.vue
+++ b/src/components/metaDataComponents/genderOfficeToggleCheckbox.vue
@@ -26,7 +26,7 @@
     v-for="(value, key) in store.options[props.type]"
     :key="key"
     :val="key"
-    :label="value.displayStr"
+    :label="value.displayStr === 'Sveriges riksdag' ? 'Enkammare' : value.displayStr"
     class="q-ml-md"
     size="sm"
     :color="!store[`${props.type}Filter`] ? 'grey' : 'accent'"


### PR DESCRIPTION
Added "Alla" to speaker and party dropdown label, added placeholder that says "Välj specifika Parti/Talare" when clicked. Quickfix of "Sveriges riksdag" in chamber filter to "Enkammare" 
fixes humlab-swedeb/swedeb-api#162