### PR TITLE
Add semantic releases (conventional commits)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
+      - name: Install semantic-release and plugins
+        run: |
+          sudo apt-get install bumpversion
+          npm install -g semantic-release \
+            @semantic-release/commit-analyzer \
+            @semantic-release/release-notes-generator \
+            @semantic-release/changelog \
+            @semantic-release/git \
+            @semantic-release/github \
+            @semantic-release/exec \
+            conventional-changelog-conventionalcommits
+      - name: Run semantic-release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: semantic-release

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,0 +1,88 @@
+branches:
+  - main
+
+plugins:
+  - - "@semantic-release/commit-analyzer"
+    - preset: conventionalcommits
+      defaultReleaseRules: true
+      parserOpts:
+        noteKeywords:
+          - BREAKING CHANGE
+          - BREAKING CHANGES
+          - BREAKING
+      releaseRules:
+        - type: feature
+          release: minor
+        - type: docs
+          scope: docs-*
+          release: minor
+        - type: docs
+          release: false
+        - type: data
+          release: patch
+        - type: ci
+          scope: ci-*
+          release: patch
+        - type: chore
+          release: false
+        - type: no-release
+          release: false
+
+  - - "@semantic-release/release-notes-generator"
+    - preset: conventionalcommits
+      parserOpts:
+        noteKeywords:
+          - BREAKING CHANGE
+          - BREAKING CHANGES
+          - BREAKING
+      writerOpts:
+        commitsSort:
+          - subject
+          - scope
+      presetConfig:
+        types:
+          - type: feat
+            section: "🍕 Features"
+          - type: feature
+            section: "🍕 Features"
+          - type: fix
+            section: "🐛 Bug Fixes"
+          - type: perf
+            section: "🔥 Performance Improvements"
+          - type: revert
+            section: "⏩ Reverts"
+          - type: docs
+            section: "📝 Documentation"
+          - type: style
+            section: "🎨 Styles"
+          - type: refactor
+            section: "🧑‍💻 Code Refactoring"
+          - type: test
+            section: "✅ Tests"
+          - type: build
+            section: "🤖 Build System"
+          - type: ci
+            section: "🔁 Continuous Integration"
+
+  - - "@semantic-release/changelog"
+    - changelogTitle: |
+        # 📦 Changelog 
+        [![conventional commits](https://img.shields.io/badge/conventional%20commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
+        [![semantic versioning](https://img.shields.io/badge/semantic%20versioning-2.0.0-green.svg)](https://semver.org)
+        > All notable changes to this project will be documented in this file
+
+  - - "@semantic-release/github"
+    - addReleases: bottom
+      assets:
+        - path: "./dist/**/*.{msi,deb,rpm,AppImage,dmg,sha256sum,bin,exe}"
+      successComment: false
+      failTitle: false
+
+  - - "@semantic-release/git"
+    - assets:
+        - LICENSE*
+        - CHANGELOG.md
+      message: |
+        chore(${nextRelease.type}): ${nextRelease.version} [skip ci]
+
+        ${nextRelease.notes}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 0.0.1 (2025-04-19)
+
+### Features
+
+* initial semantic-release bootstrap ([4e7ad61](https://github.com/humlab-swedeb/swedeb_frontend/commit/4e7ad61c855a81cf21c9bb1cf1e314ba51099874))


### PR DESCRIPTION
This branch adds configuration for:

  - automatic semver versioning using conventional commits history
  - automatic updating of CHANGELOG.md upon commit to main

See https://www.conventionalcommits.org/en/v1.0.0/

Uses commit message tagging to determin version bumps:

  - fix: increments patch part of version i.e.  1.2.0 => 1.2.1
  - feat: increments minor part of version i.e. 1.2.0 => 1.3.0
  - BREAKING CHANGE: increments major part of version i.e.  1.x.y => 2.0.0

Other tags: build:, chore:, ci:, docs:, style:, refactor:, perf:, test:

Uses Github Actions and Node sematic-release package.