### PR TITLE
fix: remove tailing `/` in publicPath in quasar.config.js

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -50,7 +50,7 @@ module.exports = configure(function (ctx) {
         API: '/v1'
       },
       // transpile: false,
-      publicPath: '/public/',
+      publicPath: '/public',
 
       // Add dependencies for transpiling with Babel (Array of string/regex)
       // (from node_modules, which are by default not transpiled).

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -55,6 +55,8 @@ const routes = [
   // but you can also remove it
   {
     path: "/:catchAll(.*)*",
+    redirect: '/',
+  /*
     component: () => import("layouts/MainLayout.vue"),
     children: [
       {
@@ -63,6 +65,7 @@ const routes = [
         meta: { title: "Sidan hittades inte" },
       },
     ],
+  */
   },
 ];
 


### PR DESCRIPTION
fix: update catch-all route to automatically redirect to `/` in routes.js