### PR TITLE
Fix PDF viewer routing and history function assignment

### DIFF
--- a/src/components/expandingTableRow.vue
+++ b/src/components/expandingTableRow.vue
@@ -238,9 +238,17 @@ const openPdf = () => {
     page: page.value
   };
   pdfStore.setRowData(data);
-  sessionStorage.setItem("pdfData", JSON.stringify(data)); // store data in session storage for new tab
-  const routeData = router.resolve("/pdf");
-  window.open(routeData.href, "_blank");
+  sessionStorage.setItem("pdfData", JSON.stringify(data));
+  const clientRoutePath = "/pdf";
+  const clientRouteHash = `#${clientRoutePath}`;
+  const resolvedClientRoute = router.resolve({ path: clientRoutePath });
+  // console.log("router.resolve().href (for debugging):", resolvedClientRoute.href);
+  // console.log("Manually constructed clientRouteHash:", clientRouteHash);
+  const spaPublicPath = '/public/';
+  const fullPathToIndexHtml = `${window.location.origin}${spaPublicPath}index.html`;
+  const finalUrlToOpen = `${fullPathToIndexHtml}${clientRouteHash}`;
+  // console.log("Attempting to open PDF at URL:", finalUrlToOpen);
+  window.open(finalUrlToOpen, "_blank");
 };
 
 const replaceNewLine = (str) => {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -17,22 +17,17 @@ import routes from "./routes";
  */
 
 export default route(function (/* { store, ssrContext } */) {
-  const createHistory = process.env.SERVER
+  const createHistoryFunction = process.env.SERVER
     ? createMemoryHistory
-    : process.env.VUE_ROUTER_MODE === "hash"
-    ? createWebHistory
-    : createWebHashHistory;
+    : process.env.VUE_ROUTER_MODE === 'history'
+      ? createWebHistory
+      : createWebHashHistory;
 
+  const routerBase = process.env.MODE === 'ssr' ? void 0 : process.env.VUE_ROUTER_BASE;
   const Router = createRouter({
     scrollBehavior: () => ({ left: 0, top: 0 }),
     routes,
-
-    // Leave this as is and make changes in quasar.conf.js instead!
-    // quasar.conf.js -> build -> vueRouterMode
-    // quasar.conf.js -> build -> publicPath
-    history: createHistory(
-      process.env.MODE === "ssr" ? void 0 : process.env.VUE_ROUTER_BASE
-    ),
+    history: createHistoryFunction(routerBase),
   });
 
   Router.beforeEach((to, from, next) => {

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -55,8 +55,6 @@ const routes = [
   // but you can also remove it
   {
     path: "/:catchAll(.*)*",
-    redirect: '/',
-  /*
     component: () => import("layouts/MainLayout.vue"),
     children: [
       {
@@ -65,7 +63,6 @@ const routes = [
         meta: { title: "Sidan hittades inte" },
       },
     ],
-  */
   },
 ];
 


### PR DESCRIPTION
Correct the assignment of the `createHistory` function and revise the URL creation logic for the PDF viewer. Roll back a temporary fix for the start page redirect after identifying the root cause.