### PR TITLE
Party abbreviation

### DIFF
--- a/src/components/expandingTableRow.vue
+++ b/src/components/expandingTableRow.vue
@@ -49,7 +49,7 @@
                 {{
                   props.props.row.party === "[-]"
                     ? $t("accessibility.partyMissing")
-                    : props.props.row.party_full
+                    : "(" + props.props.row.party +")"
                 }},&nbsp;
               </q-item-label>
               <q-item-label
@@ -158,7 +158,7 @@
                 color="white"
                 :disabled="false"
               >
- 
+
                 <q-icon left name="open_in_new" color="accent" />
                 <q-item-label>{{ $t("openSource") }} </q-item-label>
               </q-btn>

--- a/src/components/reportForm.vue
+++ b/src/components/reportForm.vue
@@ -62,6 +62,7 @@ const copyIcon = ref("content_copy");
 const copyLabel = ref("Kopiera metadata");
 
 const copy = () => {
+  console.log( feedbackStore.getFeedbackVariables(feedbackStore.data));
   navigator.clipboard.writeText(
     JSON.stringify(feedbackStore.getFeedbackVariables(feedbackStore.data))
   );

--- a/src/i18n/sv/index.js
+++ b/src/i18n/sv/index.js
@@ -597,7 +597,7 @@ export default {
     },
     10: {
       q: "Var är det en pik/dipp runt 1975 när jag söker i ordtrenderverktyget?",
-      a: `Riskdagen ändrade från hela kalenderår till riksdagsår (cirka september till juni) 1975/1976. 
+      a: `Riskdagen ändrade från hela kalenderår till riksdagsår (cirka september till juni) 1975/1976.
       Det påverkade även vilka år som angavs i riksdagsprotokollens namn (t ex från 1972 till 1978/79).
       Detta skifte påverkar i nuläget även hur ordfrekvenserna presenteras i riksdagsdebatter.se.`,
     },
@@ -643,7 +643,7 @@ export default {
     errorMessageButton: "Tillbaka till startsidan",
     metadataMissing: "metadata saknas",
     speakerMissing: "talardata saknas",
-    genderMissing: "köndata saknas",
+    genderMissing: "data om kön saknas",
     partyMissing: "partidata saknas",
   },
 

--- a/src/i18n/sv/index.js
+++ b/src/i18n/sv/index.js
@@ -597,7 +597,7 @@ export default {
     },
     10: {
       q: "Var är det en pik/dipp runt 1975 när jag söker i ordtrenderverktyget?",
-      a: `Riskdagen ändrade från hela kalenderår till riksdagsår (cirka september till juni) 1975/1976.
+      a: `Riksdagen ändrade från hela kalenderår till riksdagsår (cirka september till juni) 1975/1976.
       Det påverkade även vilka år som angavs i riksdagsprotokollens namn (t ex från 1972 till 1978/79).
       Detta skifte påverkar i nuläget även hur ordfrekvenserna presenteras i riksdagsdebatter.se.`,
     },

--- a/src/stores/feedbackDataStore.js
+++ b/src/stores/feedbackDataStore.js
@@ -19,7 +19,7 @@ export const feedbackDataStore = defineStore("feedbackDataStore", {
   actions: {
     getFeedbackVariables: (data) => {
       const feedbackVariables = {
-        ID: data.id,
+        Protokoll: data.protocol.substring(0, data.protocol.lastIndexOf(' ')),
         Kön: data.gender,
         Parti: data.party,
         //source: data.source,


### PR DESCRIPTION
Minor changes:

Only party abbreviation shown in expanded table row instead of party name + years
Error reporting metadata includes protocol name
spelling error riskdagen in FAQ -> riksdagen
