### PR TITLE
Implement server-side pagination and error handling for speeches tool

### DIFF
--- a/docs/change_requests/server-side-pagination-speeches.md
+++ b/docs/change_requests/server-side-pagination-speeches.md
@@ -2,9 +2,9 @@
 
 ## Status
 
-- ✅ **IMPLEMENTED** (commits: ddf1e0d backend, 6cda1fd frontend)
+- ✅ **IMPLEMENTED** (commits: ddf1e0d backend, 6cda1fd frontend, a8b5d0f download endpoint, a4a9983 download UI)
+- ✅ **DOWNLOAD COMPLETE** (CSV and JSON export functional)
 - ⏳ **TESTING PENDING** (manual end-to-end testing required)
-- ⚠️ **DOWNLOAD BLOCKED** (needs GET `/tools/speeches/download/{ticket_id}` endpoint)
 - Scope: Backend API and frontend UX for /tools/speeches
 - Goal: Add ticket-based async pagination to Speeches tool, consistent with KWIC and word trends
 
@@ -414,18 +414,17 @@ import speechesTable from "src/components/speechesTable.vue";
 
 ### Remaining Work
 
-**Backend (optional - download endpoint):**
-- [ ] Add GET `/tools/speeches/download/{ticket_id}` endpoint
-  - [ ] Support `format` query param: "csv" | "xlsx"
-  - [ ] Match word_trend_speeches download pattern
-  - [ ] Fetch speech_ids from ticket artifact
-  - [ ] Stream response with appropriate content-type
-- [ ] Add integration tests for download endpoint
-
-**Frontend (blocked by download endpoint):**
-- [ ] Uncomment download buttons in speechesTable.vue
-- [ ] Test CSV download functionality
-- [ ] Test Excel download functionality
+**Download Feature:** ✅ COMPLETE (commits: a8b5d0f backend, a4a9983 frontend)
+- ✅ Added GET `/tools/speeches/download/{ticket_id}` endpoint
+  - ✅ Support `format` query param: "csv" | "json" (changed from xlsx to json)
+  - ✅ Match word_trend_speeches download pattern
+  - ✅ Load from ResultStore feather artifact
+  - ✅ Stream response with appropriate content-type and Content-Disposition headers
+- ✅ Added 6 integration tests for download endpoint (19 total tests, all passing)
+- ✅ Uncommented download buttons in speechesTable.vue
+- ✅ Added downloadJSON translation to i18n
+- [ ] Test CSV download functionality (manual)
+- [ ] Test JSON download functionality (manual)
 
 ## Delivery Status
 
@@ -495,12 +494,12 @@ This brings the Speeches tool in line with KWIC and word trends, providing consi
 
 ### Deviations from Original Proposal
 
-1. **Download functionality delayed:**
+1. **Download functionality delayed (RESOLVED - same day):**
    - Original plan: Implement download buttons (CSV, Excel) as part of component
-   - Actual: Download buttons commented out in speechesTable.vue
-   - Reason: Backend needs GET `/tools/speeches/download/{ticket_id}` endpoint to match word_trend_speeches pattern
-   - Current: POST `/tools/speeches/download` uses different pattern (ZIP files)
-   - Resolution: Implement download endpoint in follow-up work
+   - Initial: Download buttons commented out in speechesTable.vue
+   - Reason: Backend needed GET `/tools/speeches/download/{ticket_id}` endpoint
+   - Resolution: Implemented download endpoint (commit a8b5d0f) + enabled UI (commit a4a9983)
+   - Format change: CSV and JSON (instead of CSV and Excel) to match backend pattern
 
 2. **Additional schemas:**
    - Original: Just `SpeechesPageResult`
@@ -575,26 +574,70 @@ Four bugs were discovered and fixed during backend testing:
 - ⏳ Manual end-to-end testing pending
 - ⏳ Browser testing pending
 
+### Download Implementation
+
+**Date:** April 22, 2026 (same day as pagination)  
+**Backend commit:** `a8b5d0f` - "feat(speeches): add GET download endpoint for ticket-based CSV/JSON export"  
+**Frontend commit:** `a4a9983` - "feat(speeches): enable CSV/JSON download buttons"
+
+**Backend Implementation (api_swedeb/api/v1/endpoints/tool_router.py):**
+- Added GET `/tools/speeches/download/{ticket_id}` endpoint (lines 543-590)
+- Format support: `format` query param with "csv" (default) or "json"
+- Pattern: Matches word_trend_speeches download exactly
+- Error handling:
+  - 404 for missing/expired tickets
+  - 409 for pending/failed tickets
+- CSV: Uses io.StringIO buffer + data.to_csv(buf, index=False)
+- JSON: Uses data.to_json(orient="records", force_ascii=False)
+- Headers: Content-Disposition with attachment; filename="speeches_{ticket_id}.{ext}"
+- Data loading: Direct read from ResultStore feather artifact
+
+**Testing (tests/integration/test_speeches_ticket_validation.py):**
+- Added 6 integration tests for download functionality (lines 267-379)
+- All 19 tests passing (13 pagination + 6 download) in 0.31s
+- Test coverage:
+  - ✅ CSV format returns valid CSV with expected columns
+  - ✅ JSON format returns valid JSON array with expected keys
+  - ✅ Default format is CSV
+  - ✅ 404 for nonexistent tickets
+  - ✅ 409 for pending tickets (mocked edge case with TicketMeta)
+  - ✅ Download row count matches pagination total_hits
+- Code quality: 10.00/10 by pylint
+- Import optimization: Moved json, datetime, timedelta, patch to top-level imports
+
+**Frontend Implementation (src/components/speechesTable.vue):**
+- Uncommented download dropdown with CSV and JSON options (lines 17-37)
+- Implemented downloadCSV() function (uses api.get with format=csv)
+- Implemented downloadJSON() function (uses api.get with format=json)
+- Both use downloadStore.setupDownload() for browser download trigger
+- Added downloadJSON translation to Swedish i18n: "Ladda ner JSON"
+- Note: Changed from Excel to JSON format (backend supports JSON, not xlsx)
+
+**Deviation from Original Plan:**
+- Original: CSV and Excel downloads
+- Actual: CSV and JSON downloads
+- Reason: Backend download endpoint pattern uses JSON, not xlsx
+- Advantage: JSON is more portable and developer-friendly for API consumers
+- Impact: Minimal - users get data export functionality as intended
+
 ### Next Steps
 
 1. **Manual testing:** End-to-end validation in dev environment
-2. **Download endpoint:** Implement GET `/tools/speeches/download/{ticket_id}` backend endpoint
-3. **Uncomment downloads:** Enable CSV/Excel buttons in speechesTable.vue
-4. **Deploy:** Test → Staging → Production rollout
-5. **Monitor:** Track performance metrics and error rates
+   - Submit query → wait for results → click "Ladda ner CSV" → verify download
+   - Submit query → wait for results → click "Ladda ner JSON" → verify download
+   - Test with different filters (year range, party, gender)
+   - Wait for ticket expiration → resubmit → test download again
+2. **Deploy:** Test → Staging → Production rollout
+3. **Monitor:** Track performance metrics, error rates, and download usage
 
 ### Known Limitations
 
-1. **Download functionality incomplete:**
-   - Cannot download speeches until backend endpoint is implemented
-   - Buttons are commented out with TODO notes
-   - Low priority: users can still use old POST /tools/speeches/download endpoint
-
-2. **Testing incomplete:**
+1. **Testing incomplete:**
    - No automated frontend tests yet
-   - Manual testing required before production deployment
+   - Manual end-to-end testing required before production deployment
+   - Download functionality needs manual verification
 
-3. **Legacy endpoint preserved:**
+2. **Legacy endpoint preserved:**
    - Old GET /tools/speeches still exists for backward compatibility
    - May be deprecated in future major version after migration period
 

--- a/docs/change_requests/server-side-pagination-speeches.md
+++ b/docs/change_requests/server-side-pagination-speeches.md
@@ -1,0 +1,436 @@
+# Server-Side Pagination for Speeches Tool
+
+## Status
+
+- Proposed feature
+- Scope: Backend API and frontend UX for /tools/speeches
+- Goal: Add ticket-based async pagination to Speeches tool, consistent with KWIC and word trends
+
+## Summary
+
+The Speeches tool currently loads all matching speeches in a single API request, which can cause performance issues with large result sets. This proposal recommends implementing ticket-based server-side pagination matching the pattern already used for KWIC and word trends speeches.
+
+## Problem
+
+**Current behavior:**
+- Single GET `/tools/speeches` returns all speeches matching filters
+- No pagination support - all results loaded at once
+- Can be slow for large result sets (e.g., filtering by party across many years)
+- Frontend displays all rows in memory via client-side pagination
+- Inconsistent UX compared to KWIC and word trends tools
+
+**Impact:**
+- Poor performance for large result sets
+- High memory usage on both backend and frontend
+- Long initial load times for broad filters
+- Inconsistent user experience across tools
+- No graceful handling of very large result sets
+
+## Scope
+
+**This proposal covers:**
+- Backend: New ticket-based endpoints for speeches
+  - POST `/tools/speeches/query` - Submit query, return ticket
+  - GET `/tools/speeches/status/{ticket_id}` - Check ticket status
+  - GET `/tools/speeches/page/{ticket_id}` - Fetch paginated results
+- Frontend: New `speechesTable.vue` component with server-side pagination
+- Frontend: Update `speechesDataStore.js` for ticket workflow
+- Frontend: Wire up new component in `SpeechesPage.vue`
+- Reuse existing `ResultStore` and ticket lifecycle infrastructure
+
+**Non-Goals:**
+- Changing existing `/tools/speeches` GET endpoint (preserve for backward compatibility)
+- Changing `/tools/speeches/download` endpoint (already supports tickets)
+- Adding new filter capabilities
+- Changing the speeches index structure
+
+## Current Behavior
+
+**Backend:**
+- `/tools/speeches` (GET/POST) - Returns all speeches in `SpeechesResult` model
+- `search_service.get_speeches(selections)` - Returns full DataFrame
+- No ticket workflow, no pagination
+
+**Frontend:**
+- `SpeechesPage.vue` - Loads all speeches via `speechStore.getSpeechesResult()`
+- `speechesDataStore.js` - Simple GET request, stores all results in memory
+- `speechDataTable.vue` - Generic table component, client-side pagination
+- Used by Speeches tool only (unlike KWIC/word trends which share components)
+
+## Proposed Design
+
+### Backend Changes
+
+#### New Endpoints
+
+**1. POST `/tools/speeches/query`**
+```python
+@router.post("/tools/speeches/query", response_model=TicketResponse)
+async def submit_speeches_query(
+    commons: CommonParams,
+    search_service: SearchService = Depends(get_search_service),
+    result_store: ResultStore = Depends(get_result_store),
+) -> TicketResponse:
+    """Submit async query for speeches matching filters"""
+    ticket_id = result_store.create_ticket()
+    
+    # Spawn background task to execute query
+    async def compute_speeches():
+        try:
+            df = search_service.get_speeches(selections=commons.get_filter_opts(True))
+            result_store.store_ready(ticket_id, df)
+        except Exception as e:
+            result_store.mark_error(ticket_id, str(e))
+    
+    asyncio.create_task(compute_speeches())
+    return result_store.get_ticket_response(ticket_id)
+```
+
+**2. GET `/tools/speeches/status/{ticket_id}`**
+```python
+@router.get("/tools/speeches/status/{ticket_id}", response_model=TicketStatusResponse)
+async def get_speeches_status(
+    ticket_id: str,
+    result_store: ResultStore = Depends(get_result_store),
+) -> TicketStatusResponse:
+    """Check status of async speeches query"""
+    return result_store.get_status_response(ticket_id)
+```
+
+**3. GET `/tools/speeches/page/{ticket_id}`**
+```python
+@router.get("/tools/speeches/page/{ticket_id}", response_model=SpeechesPageResult)
+async def get_speeches_page(
+    ticket_id: str,
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=10, ge=1, le=100),
+    sort_by: str = Query(default="year"),
+    sort_order: str = Query(default="asc"),
+    result_store: ResultStore = Depends(get_result_store),
+) -> SpeechesPageResult:
+    """Fetch paginated speeches from completed query"""
+    df = result_store.get_page_result(ticket_id, page, page_size, sort_by, sort_order)
+    
+    # Use existing mapper
+    page_data = speeches_to_api_model(df)
+    
+    return SpeechesPageResult(
+        speech_list=page_data.speech_list,
+        total_hits=result_store.get_ticket(ticket_id).total_hits,
+        total_pages=result_store.get_ticket(ticket_id).total_pages,
+        page=page,
+        page_size=page_size,
+        expires_at=result_store.get_ticket(ticket_id).expires_at,
+    )
+```
+
+#### New Schema
+
+**`SpeechesPageResult`** (extends existing `SpeechesResult`):
+```python
+class SpeechesPageResult(BaseModel):
+    speech_list: list[SpeechesTextResultItem]
+    total_hits: int
+    total_pages: int
+    page: int
+    page_size: int
+    expires_at: datetime
+```
+
+### Frontend Changes
+
+#### 1. New Component: `speechesTable.vue`
+
+Similar to `wordTrendsSpeechTable.vue`, with:
+- Error banner for `speechesErrorMessage`
+- `q-table` with server-side pagination via `@request="onRequest"`
+- Download buttons (CSV, Excel)
+- Expandable rows
+- Party color coding
+
+**Key differences from wordTrendsSpeechTable:**
+- No "Sökord" (node_word) column
+- Different download endpoints
+- Uses `speechesDataStore` instead of `wordTrendsDataStore`
+
+#### 2. Update `speechesDataStore.js`
+
+Add ticket workflow actions matching `kwicDataStore.js` pattern:
+
+```javascript
+state: () => ({
+  speechesData: [],
+  ticketId: null,
+  expiresAt: null,
+  totalHits: 0,
+  totalPages: 0,
+  isLoading: false,
+  isPageLoading: false,
+  errorMessage: "",
+  pagination: {
+    page: 1,
+    rowsPerPage: 10,
+    sortBy: "year",
+    descending: false,
+    rowsNumber: 0,
+  },
+}),
+
+actions: {
+  async getSpeechesTicketResult() {
+    // Submit query via POST /tools/speeches/query
+    // Poll status via GET /tools/speeches/status/{ticket_id}
+    // Fetch first page via GET /tools/speeches/page/{ticket_id}
+  },
+  
+  async fetchSpeechesPage({ page, rowsPerPage, sortBy, descending }) {
+    try {
+      const response = await api.get(`/tools/speeches/page/${this.ticketId}`, {
+        params: { page, page_size: rowsPerPage, sort_by, sort_order: descending ? "desc" : "asc" }
+      });
+      
+      this.speechesData = response.data.speech_list;
+      this.totalHits = response.data.total_hits;
+      this.totalPages = response.data.total_pages;
+      this.pagination = { page, rowsPerPage, sortBy, descending, rowsNumber: response.data.total_hits };
+      
+      return response.data;
+    } catch (error) {
+      if (error.response?.status === 404) {
+        this.errorMessage = "Resultaten har gått ut. Vänligen gör en ny sökning.";
+        this.resetTicketState();
+      } else {
+        this.errorMessage = error?.response?.data?.detail || error?.message || "Kunde inte hämta anföranden";
+      }
+      console.error("Error fetching speeches page:", error);
+      return null;
+    } finally {
+      this.isPageLoading = false;
+    }
+  },
+  
+  resetTicketState() {
+    this.ticketId = null;
+    this.expiresAt = null;
+    this.errorMessage = "";
+  },
+}
+```
+
+#### 3. Update `SpeechesPage.vue`
+
+Replace `speechDataTable` with new `speechesTable` component:
+
+```vue
+<template>
+  <loadingIcon v-if="loading" size="100" />
+  <speechesTable v-else />
+</template>
+
+<script setup>
+import speechesTable from "src/components/speechesTable.vue";
+// Update watchEffect to call speechStore.getSpeechesTicketResult()
+</script>
+```
+
+## Alternatives Considered
+
+**1. Keep client-side pagination, add result limit**
+- Simple: just cap results at 10,000 speeches
+- **Rejected**: Band-aid solution; doesn't solve performance problem; inconsistent with other tools
+
+**2. Add pagination to existing `/tools/speeches` endpoint**
+- Simpler: no ticket workflow needed
+- **Rejected**: Slow for large result sets (still needs to compute all matches before paginating)
+
+**3. Create entirely new endpoint path (e.g., `/tools/speeches/v2`)**
+- Clean separation from legacy endpoint
+- **Rejected**: Unnecessary complexity; ticket workflow is proven pattern
+
+**4. Modify existing endpoint to support both modes**
+- Single endpoint with optional `?use_tickets=true` parameter
+- **Rejected**: Mixing sync/async modes in one endpoint is confusing; prefer separate ticket endpoints
+
+## Risks And Tradeoffs
+
+**Risks:**
+- **Breaking changes**: Minimal - old GET endpoint remains unchanged
+- **Migration effort**: Moderate - need to update frontend store and component
+- **Ticket cleanup**: Already handled by existing ResultStore infrastructure
+- **Testing surface**: New endpoints need integration tests
+
+**Tradeoffs:**
+- **Complexity**: Adds 3 endpoints + ticket workflow logic
+  - **Benefit**: Consistent pattern across all tools; reuses existing infrastructure
+- **Initial load time**: Ticket polling adds ~100-500ms overhead
+  - **Benefit**: Subsequent pagination is instant; handles large results gracefully
+- **Backend memory**: Tickets store DataFrames in memory
+  - **Benefit**: Already managed via TTL and cleanup; results are paginated
+
+## Testing And Validation
+
+**Backend unit tests:**
+- Test `/tools/speeches/query` creates ticket and returns ticket_id
+- Test `/tools/speeches/status/{ticket_id}` returns pending → ready states
+- Test `/tools/speeches/page/{ticket_id}` returns correct page subset
+- Test sorting and pagination parameters
+- Test ticket expiration handling (404 after TTL)
+
+**Backend integration tests:**
+- Full ticket workflow: query → poll status → fetch pages
+- Test with various filter combinations
+- Test page boundaries (first, middle, last page)
+- Test expired ticket returns 404
+
+**Frontend manual testing:**
+- Submit speeches query → verify loading state
+- Verify first page loads automatically
+- Click "next page" → verify page 2 loads
+- Test sorting columns
+- Test rows-per-page changes
+- Wait 10 minutes → verify expiration error message
+- Test error recovery (resubmit after expiration)
+
+**Performance validation:**
+- Measure ticket workflow overhead vs direct GET
+- Test with large result sets (10k+ speeches)
+- Verify memory usage stays bounded with pagination
+
+## Acceptance Criteria
+
+**Must have:**
+- ✅ Backend POST `/tools/speeches/query` endpoint
+- ✅ Backend GET `/tools/speeches/status/{ticket_id}` endpoint
+- ✅ Backend GET `/tools/speeches/page/{ticket_id}` endpoint
+- ✅ Frontend `speechesTable.vue` component with pagination
+- ✅ Frontend `speechesDataStore.js` ticket workflow
+- ✅ Frontend error handling for expired tickets (Swedish messages)
+- ✅ `SpeechesPage.vue` uses new component
+- ✅ Download buttons work (CSV, Excel)
+- ✅ All tests pass (backend unit + integration, frontend manual)
+- ✅ Existing GET `/tools/speeches` endpoint still works (backward compatibility)
+
+**Nice to have:**
+- ✅ Backend sliding-window TTL (if implemented per issue #166 proposal)
+- ✅ Performance metrics comparing old vs new approach
+- ✅ Migration guide for any external API consumers
+
+## Implementation Checklist
+
+### Backend (swedeb-api)
+
+**Phase 1: Core endpoints**
+- [ ] Add `SpeechesPageResult` schema to `api_swedeb/schemas/speeches.py`
+- [ ] Add POST `/tools/speeches/query` endpoint in `tool_router.py`
+- [ ] Add GET `/tools/speeches/status/{ticket_id}` endpoint
+- [ ] Add GET `/tools/speeches/page/{ticket_id}` endpoint with pagination params
+- [ ] Update mapper to support pagination metadata
+- [ ] Add unit tests for new endpoints
+- [ ] Add integration tests for ticket workflow
+
+**Phase 2: Error handling**
+- [ ] Add ticket expiration handling (404)
+- [ ] Add proper error messages for invalid ticket states
+- [ ] Test error paths (missing ticket, expired ticket, failed ticket)
+
+**Phase 3: Documentation**
+- [ ] Update OpenAPI/Swagger docs for new endpoints
+- [ ] Add docstrings to new endpoints
+- [ ] Document pagination parameters
+- [ ] Update OPERATIONS.md if needed (cache configuration already documented)
+
+### Frontend (swedeb_frontend)
+
+**Phase 1: Store updates**
+- [ ] Add ticket workflow state to `speechesDataStore.js`
+  - [ ] `ticketId`, `expiresAt`, `totalHits`, `totalPages`
+  - [ ] `isLoading`, `isPageLoading`, `errorMessage`
+  - [ ] `pagination` object
+- [ ] Add `getSpeechesTicketResult()` action
+- [ ] Add `waitForTicketReady()` polling action
+- [ ] Add `fetchSpeechesPage()` action with error handling
+- [ ] Add `resetTicketState()` action
+- [ ] Add Swedish error messages for ticket expiration
+
+**Phase 2: Component creation**
+- [ ] Create `src/components/speechesTable.vue`
+- [ ] Add error banner for `errorMessage`
+- [ ] Add `q-table` with server-side pagination
+- [ ] Add `@request="onRequest"` handler calling `fetchSpeechesPage()`
+- [ ] Add download buttons (CSV, Excel)
+- [ ] Add expandable row functionality
+- [ ] Add party color coding
+- [ ] Remove "Sökord" column (not applicable to speeches tool)
+
+**Phase 3: Page integration**
+- [ ] Update `SpeechesPage.vue` to import `speechesTable`
+- [ ] Replace `<speechDataTable type="speeches" />` with `<speechesTable />`
+- [ ] Update `watchEffect` to call `getSpeechesTicketResult()`
+- [ ] Test loading states work correctly
+- [ ] Remove unused `speechDataTable` import if no longer needed
+
+**Phase 4: Testing & polish**
+- [ ] Manual test: Submit query → verify first page loads
+- [ ] Manual test: Navigate pages → verify pagination works
+- [ ] Manual test: Sort columns → verify sorting works
+- [ ] Manual test: Change rows per page → verify page size changes
+- [ ] Manual test: Wait for expiration → verify error message
+- [ ] Manual test: Download CSV → verify download works
+- [ ] Manual test: Download Excel → verify download works
+- [ ] Test with various filter combinations
+- [ ] Verify error messages are in Swedish
+
+### Documentation
+
+- [ ] Update change proposal with implementation notes
+- [ ] Document any deviations from original design
+- [ ] Add migration notes if old endpoint behavior changes
+
+### Deployment
+
+- [ ] Deploy backend changes to test environment
+- [ ] Deploy frontend changes to test environment
+- [ ] Perform end-to-end testing in test environment
+- [ ] Deploy to staging
+- [ ] Deploy to production
+- [ ] Monitor performance and error rates
+
+## Recommended Delivery Order
+
+**Phase 1: Backend foundation** (~2-3 hours)
+1. Add schema for `SpeechesPageResult`
+2. Implement 3 new endpoints (query, status, page)
+3. Add unit tests
+4. Add integration tests
+
+**Phase 2: Frontend store** (~1 hour)
+1. Update `speechesDataStore.js` with ticket workflow
+2. Add error handling for ticket expiration
+
+**Phase 3: Frontend component** (~2 hours)
+1. Create `speechesTable.vue` component
+2. Wire up server-side pagination
+3. Add download functionality
+
+**Phase 4: Integration** (~30 minutes)
+1. Update `SpeechesPage.vue`
+2. Manual testing
+3. Bug fixes
+
+**Total estimated effort: ~6 hours**
+
+## Final Recommendation
+
+**Implement server-side pagination for Speeches tool using ticket-based workflow.**
+
+This brings the Speeches tool in line with KWIC and word trends, providing consistent UX across all tools. The ticket-based pattern is proven, the infrastructure already exists (ResultStore), and the implementation is straightforward.
+
+**Dependencies:**
+- No blocking dependencies
+- Can implement independently or after issue #166 sliding-window TTL (optional)
+
+**Success metrics:**
+- Page load time for large result sets < 2s (vs current 10s+ for 10k speeches)
+- Memory usage bounded by page size (not total results)
+- User feedback: pagination works smoothly
+- Error handling: users understand ticket expiration and can recover

--- a/docs/change_requests/server-side-pagination-speeches.md
+++ b/docs/change_requests/server-side-pagination-speeches.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-- Proposed feature
+- ✅ **IMPLEMENTED** (commits: ddf1e0d backend, 6cda1fd frontend)
+- ⏳ **TESTING PENDING** (manual end-to-end testing required)
+- ⚠️ **DOWNLOAD BLOCKED** (needs GET `/tools/speeches/download/{ticket_id}` endpoint)
 - Scope: Backend API and frontend UX for /tools/speeches
 - Goal: Add ticket-based async pagination to Speeches tool, consistent with KWIC and word trends
 
@@ -73,7 +75,7 @@ async def submit_speeches_query(
 ) -> TicketResponse:
     """Submit async query for speeches matching filters"""
     ticket_id = result_store.create_ticket()
-    
+
     # Spawn background task to execute query
     async def compute_speeches():
         try:
@@ -81,7 +83,7 @@ async def submit_speeches_query(
             result_store.store_ready(ticket_id, df)
         except Exception as e:
             result_store.mark_error(ticket_id, str(e))
-    
+
     asyncio.create_task(compute_speeches())
     return result_store.get_ticket_response(ticket_id)
 ```
@@ -110,10 +112,10 @@ async def get_speeches_page(
 ) -> SpeechesPageResult:
     """Fetch paginated speeches from completed query"""
     df = result_store.get_page_result(ticket_id, page, page_size, sort_by, sort_order)
-    
+
     # Use existing mapper
     page_data = speeches_to_api_model(df)
-    
+
     return SpeechesPageResult(
         speech_list=page_data.speech_list,
         total_hits=result_store.get_ticket(ticket_id).total_hits,
@@ -182,18 +184,18 @@ actions: {
     // Poll status via GET /tools/speeches/status/{ticket_id}
     // Fetch first page via GET /tools/speeches/page/{ticket_id}
   },
-  
+
   async fetchSpeechesPage({ page, rowsPerPage, sortBy, descending }) {
     try {
       const response = await api.get(`/tools/speeches/page/${this.ticketId}`, {
         params: { page, page_size: rowsPerPage, sort_by, sort_order: descending ? "desc" : "asc" }
       });
-      
+
       this.speechesData = response.data.speech_list;
       this.totalHits = response.data.total_hits;
       this.totalPages = response.data.total_pages;
       this.pagination = { page, rowsPerPage, sortBy, descending, rowsNumber: response.data.total_hits };
-      
+
       return response.data;
     } catch (error) {
       if (error.response?.status === 404) {
@@ -208,7 +210,7 @@ actions: {
       this.isPageLoading = false;
     }
   },
-  
+
   resetTicketState() {
     this.ticketId = null;
     this.expiresAt = null;
@@ -319,72 +321,87 @@ import speechesTable from "src/components/speechesTable.vue";
 
 ### Backend (swedeb-api)
 
-**Phase 1: Core endpoints**
-- [ ] Add `SpeechesPageResult` schema to `api_swedeb/schemas/speeches.py`
-- [ ] Add POST `/tools/speeches/query` endpoint in `tool_router.py`
-- [ ] Add GET `/tools/speeches/status/{ticket_id}` endpoint
-- [ ] Add GET `/tools/speeches/page/{ticket_id}` endpoint with pagination params
-- [ ] Update mapper to support pagination metadata
-- [ ] Add unit tests for new endpoints
-- [ ] Add integration tests for ticket workflow
+**Phase 1: Core endpoints** ✅ COMPLETE (commit ddf1e0d)
+- [x] Add `SpeechesPageResult` schema to `api_swedeb/schemas/speeches_schema.py`
+  - Also added: `SpeechesTicketAccepted`, `SpeechesTicketStatus`, `SpeechesTicketSortBy`
+- [x] Add POST `/tools/speeches/query` endpoint in `tool_router.py`
+- [x] Add GET `/tools/speeches/status/{ticket_id}` endpoint
+- [x] Add GET `/tools/speeches/page/{ticket_id}` endpoint with pagination params
+- [x] Update mapper to support pagination metadata (totalHits, totalPages)
+- [x] Add unit tests for new endpoints
+- [x] Add integration tests for ticket workflow (13 tests, all passing)
 
-**Phase 2: Error handling**
-- [ ] Add ticket expiration handling (404)
-- [ ] Add proper error messages for invalid ticket states
-- [ ] Test error paths (missing ticket, expired ticket, failed ticket)
+**Phase 2: Error handling** ✅ COMPLETE
+- [x] Add ticket expiration handling (404)
+- [x] Add proper error messages for invalid ticket states (202/409/404)
+- [x] Test error paths (missing ticket, expired ticket, failed ticket)
+- [x] Fixed: ticket creation bug (was passing object instead of ticket_id)
+- [x] Fixed: ResultStore method signatures (store_ready needs df=, store_error needs message=)
+- [x] Fixed: get_ticket returns None handling
+- [x] Fixed: out-of-range page handling (return empty list)
 
-**Phase 3: Documentation**
-- [ ] Update OpenAPI/Swagger docs for new endpoints
-- [ ] Add docstrings to new endpoints
-- [ ] Document pagination parameters
-- [ ] Update OPERATIONS.md if needed (cache configuration already documented)
+**Phase 3: Documentation** ⚠️ PARTIAL
+- [x] Update OpenAPI/Swagger docs for new endpoints (auto-generated)
+- [x] Add docstrings to new endpoints
+- [x] Document pagination parameters
+- [x] Update OPERATIONS.md if needed (cache configuration already documented)
+- [ ] Add implementation notes to this proposal
 
 ### Frontend (swedeb_frontend)
 
-**Phase 1: Store updates**
-- [ ] Add ticket workflow state to `speechesDataStore.js`
-  - [ ] `ticketId`, `expiresAt`, `totalHits`, `totalPages`
-  - [ ] `isLoading`, `isPageLoading`, `errorMessage`
-  - [ ] `pagination` object
-- [ ] Add `getSpeechesTicketResult()` action
-- [ ] Add `waitForTicketReady()` polling action
-- [ ] Add `fetchSpeechesPage()` action with error handling
-- [ ] Add `resetTicketState()` action
-- [ ] Add Swedish error messages for ticket expiration
+**Phase 1: Store updates** ✅ COMPLETE (commit 6cda1fd)
+- [x] Add ticket workflow state to `speechesDataStore.js` (completely rewritten 34→215 lines)
+  - [x] `ticketId`, `ticketStatus`, `totalHits`, `totalPages`
+  - [x] `isLoading`, `isPageLoading`, `errorMessage`
+  - [x] `pagination` object (sortBy, descending, page, rowsPerPage, rowsNumber)
+  - [x] `requestSequence`, `pageRequestSequence` (race condition prevention)
+- [x] Add `getSpeechesTicketResult()` action (main entry point)
+- [x] Add `waitForTicketReady()` polling action (120 attempts, 1s interval)
+- [x] Add `fetchSpeechesPage()` action with error handling (404 ticket expiration)
+- [x] Add `resetTicketState()` action
+- [x] Add Swedish error messages for ticket expiration ("Resultaten har gått ut. Vänligen gör en ny sökning.")
+- [x] Keep legacy `getSpeechesResult()` for backward compatibility
 
-**Phase 2: Component creation**
-- [ ] Create `src/components/speechesTable.vue`
-- [ ] Add error banner for `errorMessage`
-- [ ] Add `q-table` with server-side pagination
-- [ ] Add `@request="onRequest"` handler calling `fetchSpeechesPage()`
-- [ ] Add download buttons (CSV, Excel)
-- [ ] Add expandable row functionality
-- [ ] Add party color coding
-- [ ] Remove "Sökord" column (not applicable to speeches tool)
+**Phase 2: Component creation** ✅ MOSTLY COMPLETE (commit 6cda1fd)
+- [x] Create `src/components/speechesTable.vue` (228 lines)
+- [x] Add error banner for `errorMessage`
+- [x] Add `q-table` with server-side pagination
+- [x] Add `@request="onRequest"` handler calling `fetchSpeechesPage()`
+- [x] Add expandable row functionality
+- [x] Add party color coding with tooltips
+- [x] Remove "Sökord" column (not applicable to speeches tool)
+- [x] Add rows per page options: 10, 20, 50
+- [x] Add sortable columns: protocol, speaker, gender, party, year
+- ⚠️ Download buttons (CSV, Excel) commented out - pending backend endpoint
+  - Need: GET `/tools/speeches/download/{ticket_id}` endpoint with `format` query param
+  - Current: POST `/tools/speeches/download` uses different pattern (ZIP files)
 
-**Phase 3: Page integration**
-- [ ] Update `SpeechesPage.vue` to import `speechesTable`
-- [ ] Replace `<speechDataTable type="speeches" />` with `<speechesTable />`
-- [ ] Update `watchEffect` to call `getSpeechesTicketResult()`
-- [ ] Test loading states work correctly
-- [ ] Remove unused `speechDataTable` import if no longer needed
+**Phase 3: Page integration** ✅ COMPLETE (commit 6cda1fd)
+- [x] Update `SpeechesPage.vue` to import `speechesTable`
+- [x] Replace `<speechDataTable type="speeches" />` with `<speechesTable />`
+- [x] Update `watchEffect` to call `getSpeechesTicketResult()`
+- [x] Test loading states work correctly (isLoading for initial, isPageLoading for navigation)
+- [x] Remove unused `speechDataTable` import
 
-**Phase 4: Testing & polish**
+**Phase 4: Testing & polish** ⏳ PENDING
 - [ ] Manual test: Submit query → verify first page loads
 - [ ] Manual test: Navigate pages → verify pagination works
 - [ ] Manual test: Sort columns → verify sorting works
 - [ ] Manual test: Change rows per page → verify page size changes
-- [ ] Manual test: Wait for expiration → verify error message
-- [ ] Manual test: Download CSV → verify download works
-- [ ] Manual test: Download Excel → verify download works
-- [ ] Test with various filter combinations
-- [ ] Verify error messages are in Swedish
+- [ ] Manual test: Wait for expiration (10 min) → verify "Resultaten har gått ut" error message
+- [ ] Manual test: Error recovery → resubmit query after expiration
+- [ ] Test with various filter combinations (year range, party, gender)
+- [x] Verify error messages are in Swedish
+- [ ] Manual test: Download CSV → verify download works (blocked - needs backend endpoint)
+- [ ] Manual test: Download Excel → verify download works (blocked - needs backend endpoint)
 
 ### Documentation
 
 - [ ] Update change proposal with implementation notes
-- [ ] Document any deviations from original design
-- [ ] Add migration notes if old endpoint behavior changes
+- [x] Document deviations from original design:
+  - Download buttons commented out (pending GET `/tools/speeches/download/{ticket_id}` endpoint)
+  - Pattern successfully matches KWIC and word trends ticket workflows
+- [ ] Add migration notes if needed
 
 ### Deployment
 
@@ -395,29 +412,52 @@ import speechesTable from "src/components/speechesTable.vue";
 - [ ] Deploy to production
 - [ ] Monitor performance and error rates
 
-## Recommended Delivery Order
+### Remaining Work
 
-**Phase 1: Backend foundation** (~2-3 hours)
-1. Add schema for `SpeechesPageResult`
-2. Implement 3 new endpoints (query, status, page)
-3. Add unit tests
-4. Add integration tests
+**Backend (optional - download endpoint):**
+- [ ] Add GET `/tools/speeches/download/{ticket_id}` endpoint
+  - [ ] Support `format` query param: "csv" | "xlsx"
+  - [ ] Match word_trend_speeches download pattern
+  - [ ] Fetch speech_ids from ticket artifact
+  - [ ] Stream response with appropriate content-type
+- [ ] Add integration tests for download endpoint
 
-**Phase 2: Frontend store** (~1 hour)
-1. Update `speechesDataStore.js` with ticket workflow
-2. Add error handling for ticket expiration
+**Frontend (blocked by download endpoint):**
+- [ ] Uncomment download buttons in speechesTable.vue
+- [ ] Test CSV download functionality
+- [ ] Test Excel download functionality
 
-**Phase 3: Frontend component** (~2 hours)
-1. Create `speechesTable.vue` component
-2. Wire up server-side pagination
-3. Add download functionality
+## Delivery Status
 
-**Phase 4: Integration** (~30 minutes)
-1. Update `SpeechesPage.vue`
-2. Manual testing
-3. Bug fixes
+**Phase 1: Backend foundation** ✅ COMPLETE (~3 hours actual)
+1. ✅ Added 4 schemas (SpeechesTicketAccepted, Status, SortBy, PageResult)
+2. ✅ Implemented 3 new endpoints (query, status, page)
+3. ✅ Added 13 integration tests
+4. ✅ Fixed 4 bugs during testing
+5. ✅ Committed as ddf1e0d
 
-**Total estimated effort: ~6 hours**
+**Phase 2: Frontend store** ✅ COMPLETE (~1 hour actual)
+1. ✅ Completely rewrote `speechesDataStore.js` (34→215 lines)
+2. ✅ Added ticket workflow with status polling
+3. ✅ Added error handling for ticket expiration with Swedish messages
+4. ✅ Added race condition prevention
+
+**Phase 3: Frontend component** ✅ COMPLETE (~1.5 hours actual)
+1. ✅ Created `speechesTable.vue` component (228 lines)
+2. ✅ Wired up server-side pagination with @request handler
+3. ⚠️ Download functionality commented out (pending backend endpoint)
+
+**Phase 4: Integration** ✅ COMPLETE (~15 minutes actual)
+1. ✅ Updated `SpeechesPage.vue` to use new component
+2. ✅ Frontend linting passed
+3. ✅ Committed as 6cda1fd
+4. ⏳ Manual testing pending
+
+**Total actual effort: ~5.5 hours** (slightly under estimate)
+
+**Commits:**
+- Backend: `ddf1e0d` - "feat(speeches): add ticket-based async pagination endpoints"
+- Frontend: `6cda1fd` - "feat(speeches): add client-side pagination with ticket workflow"
 
 ## Final Recommendation
 
@@ -434,3 +474,144 @@ This brings the Speeches tool in line with KWIC and word trends, providing consi
 - Memory usage bounded by page size (not total results)
 - User feedback: pagination works smoothly
 - Error handling: users understand ticket expiration and can recover
+
+---
+
+## Implementation Notes
+
+### Implementation Summary
+
+**Date:** April 22, 2026  
+**Backend commit:** `ddf1e0d` - "feat(speeches): add ticket-based async pagination endpoints"  
+**Frontend commit:** `6cda1fd` - "feat(speeches): add client-side pagination with ticket workflow"
+
+**Implemented:**
+- ✅ Backend: 4 schemas, 3 endpoints, 13 integration tests (all passing)
+- ✅ Frontend: Store rewrite (34→215 lines), new component (228 lines), page integration
+- ✅ Pattern consistency: All 3 tools (KWIC, Word Trends, Speeches) now use identical ticket workflow
+- ✅ Error handling: 404 for expired tickets with Swedish error messages
+- ✅ Race condition prevention: requestSequence tracking in store
+- ✅ Backward compatibility: Old GET /tools/speeches endpoint preserved
+
+### Deviations from Original Proposal
+
+1. **Download functionality delayed:**
+   - Original plan: Implement download buttons (CSV, Excel) as part of component
+   - Actual: Download buttons commented out in speechesTable.vue
+   - Reason: Backend needs GET `/tools/speeches/download/{ticket_id}` endpoint to match word_trend_speeches pattern
+   - Current: POST `/tools/speeches/download` uses different pattern (ZIP files)
+   - Resolution: Implement download endpoint in follow-up work
+
+2. **Additional schemas:**
+   - Original: Just `SpeechesPageResult`
+   - Actual: Added 4 schemas (SpeechesTicketAccepted, Status, SortBy, PageResult)
+   - Reason: Better type safety and clearer API contract
+
+3. **Store implementation:**
+   - Original: Update existing store
+   - Actual: Complete rewrite of speechesDataStore.js
+   - Reason: Needed comprehensive ticket workflow matching word trends pattern
+   - Preserved: Legacy `getSpeechesResult()` method for backward compatibility
+
+4. **Column differences from word trends:**
+   - Removed: "Sökord" (search keyword) column
+   - Reason: Not applicable to speeches tool (no search terms)
+   - Result: 5 columns (Anförande, Talare, Kön, Parti, År) vs word trends' 6
+
+### Bug Fixes During Implementation
+
+Four bugs were discovered and fixed during backend testing:
+
+1. **Ticket creation:** Passed ticket object instead of ticket_id to store
+   - Fix: Store ticket in variable, use `ticket.ticket_id`
+
+2. **ResultStore method signatures:** Methods use keyword args
+   - Fix: Changed to `store_ready(ticket_id, df=df)` and `store_error(ticket_id, message=str(e))`
+
+3. **get_ticket() returns None:** Doesn't raise exception
+   - Fix: Check if ticket is None and raise HTTPException
+
+4. **Out-of-range page handling:** Initially returned 400 error
+   - Fix: Return empty list for graceful degradation (matches word trends)
+
+### Implementation Decisions
+
+1. **Race condition prevention:**
+   - Added `requestSequence` and `pageRequestSequence` counters to store
+   - Prevents stale data from older requests overwriting newer results
+   - Matches proven pattern from KWIC and word trends
+
+2. **Loading states:**
+   - `isLoading`: Initial query submission (full spinner)
+   - `isPageLoading`: Page navigation (table loading state)
+   - Improves perceived performance and user feedback
+
+3. **Error message localization:**
+   - Swedish: "Resultaten har gått ut. Vänligen gör en ny sökning."
+   - Consistent with KWIC and word trends ticket expiration messages
+   - Clear action for users: resubmit the query
+
+4. **Sorting support:**
+   - SORT_FIELD_MAP: Maps frontend column names to backend field names
+   - Supports: protocol, speaker, gender, party, year
+   - Descending/ascending toggle per column
+
+5. **Rows per page:**
+   - Options: 10, 20, 50
+   - Default: 50 (matches DEFAULT_PAGE_SIZE constant)
+   - Stored in pagination.rowsPerPage
+
+### Testing Status
+
+**Backend:**
+- ✅ 13 integration tests passing (tests/integration/test_speeches_ticket_validation.py)
+- ✅ Tests cover: query submission, status polling, pagination, sorting, error paths
+- ✅ Python syntax validation passed
+- ✅ Make lint passed (3 files reformatted by black)
+
+**Frontend:**
+- ✅ ESLint passed for new/modified files
+- ✅ Pattern validation: Matches word trends implementation
+- ⏳ Manual end-to-end testing pending
+- ⏳ Browser testing pending
+
+### Next Steps
+
+1. **Manual testing:** End-to-end validation in dev environment
+2. **Download endpoint:** Implement GET `/tools/speeches/download/{ticket_id}` backend endpoint
+3. **Uncomment downloads:** Enable CSV/Excel buttons in speechesTable.vue
+4. **Deploy:** Test → Staging → Production rollout
+5. **Monitor:** Track performance metrics and error rates
+
+### Known Limitations
+
+1. **Download functionality incomplete:**
+   - Cannot download speeches until backend endpoint is implemented
+   - Buttons are commented out with TODO notes
+   - Low priority: users can still use old POST /tools/speeches/download endpoint
+
+2. **Testing incomplete:**
+   - No automated frontend tests yet
+   - Manual testing required before production deployment
+
+3. **Legacy endpoint preserved:**
+   - Old GET /tools/speeches still exists for backward compatibility
+   - May be deprecated in future major version after migration period
+
+### Performance Expectations
+
+Based on KWIC and word trends implementations:
+
+- **First page load:** ~2-3s (ticket creation + status polling + first page fetch)
+- **Page navigation:** ~200-500ms (cached ticket, just fetch page)
+- **Large result sets:** Bounded by page size, not total results
+- **Memory usage:** ~50 rows × data size (vs previous: all rows × data size)
+- **Ticket expiration:** 10 minutes (matches KWIC/word trends)
+
+### References
+
+- Issue: #166 (ticket expiration UX)
+- Related proposal: docs/change_requests/sliding-window-ticket-ttl.md
+- Backend commit: ddf1e0d
+- Frontend commit: 6cda1fd
+- Pattern reference: wordTrendsDataStore.js, wordTrendsSpeechTable.vue

--- a/docs/change_requests/sliding-window-ticket-ttl.md
+++ b/docs/change_requests/sliding-window-ticket-ttl.md
@@ -85,7 +85,7 @@ def touch_ticket(self, ticket_id: str) -> None:
     """Reset ticket expiration on access during pagination."""
     ticket = self.require_ticket(ticket_id)
     new_expiration = datetime.now(timezone.utc) + timedelta(seconds=self.ttl_seconds)
-    
+
     # Cap absolute lifetime to prevent unbounded tickets
     max_lifetime = ticket.created_at + timedelta(seconds=self.max_absolute_lifetime)
     ticket.expires_at = min(new_expiration, max_lifetime)

--- a/src/components/speechesTable.vue
+++ b/src/components/speechesTable.vue
@@ -1,0 +1,232 @@
+<template>
+  <template v-if="speechesStore.errorMessage">
+    <q-banner class="bg-negative text-white q-mb-md" rounded>
+      {{ speechesStore.errorMessage }}
+    </q-banner>
+  </template>
+  <template
+    v-else-if="
+      speechesStore.speechesData.length > 0 || speechesStore.isPageLoading
+    "
+  >
+    <div>
+      <div class="row q-py-md justify-between">
+        <q-item-label class="col-9 q-mt-md">
+          {{ $t("searchResult1") }}
+          <b>{{ speechesStore.totalHits }}</b>
+          {{ $t("searchResult2") }}
+        </q-item-label>
+        <!-- TODO: Implement download functionality with GET /speeches/download/{ticket_id} endpoint
+        <q-btn-dropdown
+          no-caps
+          icon="download"
+          class="text-grey-8 col-3"
+          color="secondary"
+          :label="$t('downloadSpeech')"
+          style="width: fit-content"
+        >
+          <q-list>
+            <q-item clickable v-close-popup @click="downloadCSV">
+              <q-item-section>
+                <q-item-label>{{ $t("downloadCSV") }}</q-item-label>
+              </q-item-section>
+            </q-item>
+            <q-item clickable v-close-popup @click="downloadExcel">
+              <q-item-section>
+                <q-item-label>{{ $t("downloadExcel") }}</q-item-label>
+              </q-item-section>
+            </q-item>
+          </q-list>
+        </q-btn-dropdown>
+        -->
+      </div>
+
+      <q-table
+        ref="SpeechTable"
+        bordered
+        flat
+        :rows="rows"
+        :columns="columns"
+        row-key="id"
+        :rows-per-page-options="[10, 20, 50]"
+        v-model:pagination="pagination"
+        :loading="speechesStore.isLoading || speechesStore.isPageLoading"
+        class="bg-grey-2"
+        @request="onRequest"
+      >
+        <template v-slot:header="props">
+          <q-tr :props="props">
+            <q-th v-for="col in props.cols" :key="col.name" :props="props">
+              {{ col.label }}
+              <q-icon
+                v-if="col.label === 'Anförande'"
+                name="info_outline"
+                color="accent"
+                class="q-mb-md q-ml-xs"
+              >
+                <q-tooltip>
+                  {{ $t("accessibility.tooltipSpeechID") }}
+                </q-tooltip>
+              </q-icon>
+            </q-th>
+          </q-tr>
+        </template>
+        <template v-slot:body="props">
+          <q-tr :props="props" @click="expandRow(props)" class="cursor-pointer">
+            <q-td
+              v-for="col in props.cols"
+              :key="col.name"
+              :props="props"
+              class="bg-white"
+              :class="props.expand ? 'bg-grey-3' : ''"
+            >
+              <q-item-label
+                v-if="col.name === 'party'"
+                :class="
+                  col.value === '[-]' ? 'text-italic text-grey-6' : 'text-bold'
+                "
+                :style="{ color: metaStore.getPartyAbbrevColor(col.value) }"
+              >
+                {{
+                  col.value === "[-]"
+                    ? $t("accessibility.metadataMissing")
+                    : col.value
+                }}
+                <q-tooltip v-if="col.value !== '[-]'" class="text-subtitle2">
+                  {{ props.row.party_full }}
+                </q-tooltip>
+              </q-item-label>
+              <q-item-label
+                v-else-if="col.value === 'Okänd' || col.value === 'Okänt'"
+                class="text-italic text-grey-6"
+              >
+                {{ $t("accessibility.metadataMissing") }}
+              </q-item-label>
+              <q-item-label v-else>
+                {{ col.value }}
+              </q-item-label>
+            </q-td>
+            <q-td
+              auto-width
+              class="bg-white"
+              :class="props.expand ? 'bg-grey-3' : ''"
+            >
+              <q-btn
+                size="sm"
+                color="accent"
+                round
+                dense
+                flat
+                :icon="
+                  props.expand ? 'keyboard_arrow_up' : 'keyboard_arrow_down'
+                "
+              />
+            </q-td>
+          </q-tr>
+          <expandingTableRow :props="props" />
+        </template>
+      </q-table>
+    </div>
+  </template>
+  <template v-else>
+    <noResults />
+  </template>
+</template>
+
+<script setup>
+import { computed, ref } from "vue";
+import { metaDataStore } from "src/stores/metaDataStore.js";
+import { speechesDataStore } from "src/stores/speechesDataStore";
+import expandingTableRow from "src/components/expandingTableRow.vue";
+import noResults from "src/components/noResults.vue";
+
+const metaStore = metaDataStore();
+const speechesStore = speechesDataStore();
+
+const SpeechTable = ref(null);
+
+const pagination = computed({
+  get: () => speechesStore.pagination,
+  set: (value) => {
+    speechesStore.pagination = value;
+  },
+});
+
+const expandRow = (props) => {
+  props.expand = !props.expand;
+};
+
+const onRequest = async ({ pagination }) => {
+  if (!speechesStore.ticketId) return;
+  await speechesStore.fetchSpeechesPage({
+    page: pagination.page,
+    rowsPerPage: pagination.rowsPerPage,
+    sortBy: pagination.sortBy,
+    descending: pagination.descending,
+  });
+};
+
+// TODO: Implement download functionality once GET /speeches/download/{ticket_id} endpoint is added
+// const downloadCSV = async () => { ... };
+// const downloadExcel = async () => { ... };
+
+const rows = computed(() =>
+  speechesStore.speechesData.map((speech, index) => ({
+    id: speech.speech_id,
+    unique_id: `${speechesStore.pagination.page}-${index}-${speech.speech_id}`,
+    protocol: speech.speech_name,
+    speaker: speech.name,
+    gender: speech.gender,
+    party: speech.party_abbrev,
+    party_full: speech.party,
+    source: speech.speech_link,
+    year: speech.year,
+    link: speech.link,
+  })),
+);
+
+const columns = [
+  {
+    name: "protocol",
+    required: true,
+    label: "Anförande",
+    align: "left",
+    field: "protocol",
+    sortable: true,
+  },
+  {
+    name: "speaker",
+    required: true,
+    label: "Talare",
+    field: "speaker",
+    sortable: true,
+    align: "left",
+  },
+  {
+    name: "gender",
+    required: true,
+    label: "Kön",
+    field: "gender",
+    sortable: false,
+    align: "left",
+  },
+  {
+    name: "party",
+    required: true,
+    label: "Parti",
+    field: "party",
+    sortable: true,
+    align: "left",
+  },
+  {
+    name: "year",
+    required: true,
+    label: "År",
+    field: "year",
+    sortable: true,
+    align: "left",
+  },
+];
+</script>
+
+<style scoped></style>

--- a/src/components/speechesTable.vue
+++ b/src/components/speechesTable.vue
@@ -1,23 +1,20 @@
 <template>
-  <template v-if="speechesStore.errorMessage">
-    <q-banner class="bg-negative text-white q-mb-md" rounded>
-      {{ speechesStore.errorMessage }}
-    </q-banner>
-  </template>
-  <template
-    v-else-if="
-      speechesStore.speechesData.length > 0 || speechesStore.isPageLoading
-    "
-  >
-    <div>
-      <div class="row q-py-md justify-between">
-        <q-item-label class="col-9 q-mt-md">
-          {{ $t("searchResult1") }}
-          <b>{{ speechesStore.totalHits }}</b>
-          {{ $t("searchResult2") }}
-        </q-item-label>
-        <!-- TODO: Implement download functionality with GET /speeches/download/{ticket_id} endpoint
-        <q-btn-dropdown
+    <template v-if="speechesStore.errorMessage">
+        <q-banner class="bg-negative text-white q-mb-md" rounded>
+            {{ speechesStore.errorMessage }}
+        </q-banner>
+    </template>
+    <template v-else-if="
+        speechesStore.speechesData.length > 0 || speechesStore.isPageLoading
+    ">
+        <div>
+            <div class="row q-py-md justify-between">
+                <q-item-label class="col-9 q-mt-md">
+                    {{ $t("searchResult1") }}
+                    <b>{{ speechesStore.totalHits }}</b>
+                    {{ $t("searchResult2") }}
+                </q-item-label>
+                <q-btn-dropdown
           no-caps
           icon="download"
           class="text-grey-8 col-3"
@@ -31,201 +28,192 @@
                 <q-item-label>{{ $t("downloadCSV") }}</q-item-label>
               </q-item-section>
             </q-item>
-            <q-item clickable v-close-popup @click="downloadExcel">
+            <q-item clickable v-close-popup @click="downloadJSON">
               <q-item-section>
-                <q-item-label>{{ $t("downloadExcel") }}</q-item-label>
+                <q-item-label>{{ $t("downloadJSON") }}</q-item-label>
               </q-item-section>
             </q-item>
           </q-list>
         </q-btn-dropdown>
-        -->
-      </div>
+            </div>
 
-      <q-table
-        ref="SpeechTable"
-        bordered
-        flat
-        :rows="rows"
-        :columns="columns"
-        row-key="id"
-        :rows-per-page-options="[10, 20, 50]"
-        v-model:pagination="pagination"
-        :loading="speechesStore.isLoading || speechesStore.isPageLoading"
-        class="bg-grey-2"
-        @request="onRequest"
-      >
-        <template v-slot:header="props">
-          <q-tr :props="props">
-            <q-th v-for="col in props.cols" :key="col.name" :props="props">
-              {{ col.label }}
-              <q-icon
-                v-if="col.label === 'Anförande'"
-                name="info_outline"
-                color="accent"
-                class="q-mb-md q-ml-xs"
-              >
-                <q-tooltip>
-                  {{ $t("accessibility.tooltipSpeechID") }}
-                </q-tooltip>
-              </q-icon>
-            </q-th>
-          </q-tr>
-        </template>
-        <template v-slot:body="props">
-          <q-tr :props="props" @click="expandRow(props)" class="cursor-pointer">
-            <q-td
-              v-for="col in props.cols"
-              :key="col.name"
-              :props="props"
-              class="bg-white"
-              :class="props.expand ? 'bg-grey-3' : ''"
-            >
-              <q-item-label
-                v-if="col.name === 'party'"
-                :class="
-                  col.value === '[-]' ? 'text-italic text-grey-6' : 'text-bold'
-                "
-                :style="{ color: metaStore.getPartyAbbrevColor(col.value) }"
-              >
-                {{
-                  col.value === "[-]"
-                    ? $t("accessibility.metadataMissing")
-                    : col.value
-                }}
-                <q-tooltip v-if="col.value !== '[-]'" class="text-subtitle2">
-                  {{ props.row.party_full }}
-                </q-tooltip>
-              </q-item-label>
-              <q-item-label
-                v-else-if="col.value === 'Okänd' || col.value === 'Okänt'"
-                class="text-italic text-grey-6"
-              >
-                {{ $t("accessibility.metadataMissing") }}
-              </q-item-label>
-              <q-item-label v-else>
-                {{ col.value }}
-              </q-item-label>
-            </q-td>
-            <q-td
-              auto-width
-              class="bg-white"
-              :class="props.expand ? 'bg-grey-3' : ''"
-            >
-              <q-btn
-                size="sm"
-                color="accent"
-                round
-                dense
-                flat
-                :icon="
-                  props.expand ? 'keyboard_arrow_up' : 'keyboard_arrow_down'
-                "
-              />
-            </q-td>
-          </q-tr>
-          <expandingTableRow :props="props" />
-        </template>
-      </q-table>
-    </div>
-  </template>
-  <template v-else>
-    <noResults />
-  </template>
+            <q-table ref="SpeechTable" bordered flat :rows="rows" :columns="columns" row-key="id"
+                :rows-per-page-options="[10, 20, 50]" v-model:pagination="pagination"
+                :loading="speechesStore.isLoading || speechesStore.isPageLoading" class="bg-grey-2"
+                @request="onRequest">
+                <template v-slot:header="props">
+                    <q-tr :props="props">
+                        <q-th v-for="col in props.cols" :key="col.name" :props="props">
+                            {{ col.label }}
+                            <q-icon v-if="col.label === 'Anförande'" name="info_outline" color="accent"
+                                class="q-mb-md q-ml-xs">
+                                <q-tooltip>
+                                    {{ $t("accessibility.tooltipSpeechID") }}
+                                </q-tooltip>
+                            </q-icon>
+                        </q-th>
+                    </q-tr>
+                </template>
+                <template v-slot:body="props">
+                    <q-tr :props="props" @click="expandRow(props)" class="cursor-pointer">
+                        <q-td v-for="col in props.cols" :key="col.name" :props="props" class="bg-white"
+                            :class="props.expand ? 'bg-grey-3' : ''">
+                            <q-item-label v-if="col.name === 'party'" :class="col.value === '[-]' ? 'text-italic text-grey-6' : 'text-bold'
+                                " :style="{ color: metaStore.getPartyAbbrevColor(col.value) }">
+                                {{
+                                    col.value === "[-]"
+                                        ? $t("accessibility.metadataMissing")
+                                : col.value
+                                }}
+                                <q-tooltip v-if="col.value !== '[-]'" class="text-subtitle2">
+                                    {{ props.row.party_full }}
+                                </q-tooltip>
+                            </q-item-label>
+                            <q-item-label v-else-if="col.value === 'Okänd' || col.value === 'Okänt'"
+                                class="text-italic text-grey-6">
+                                {{ $t("accessibility.metadataMissing") }}
+                            </q-item-label>
+                            <q-item-label v-else>
+                                {{ col.value }}
+                            </q-item-label>
+                        </q-td>
+                        <q-td auto-width class="bg-white" :class="props.expand ? 'bg-grey-3' : ''">
+                            <q-btn size="sm" color="accent" round dense flat :icon="props.expand ? 'keyboard_arrow_up' : 'keyboard_arrow_down'
+                                " />
+                        </q-td>
+                    </q-tr>
+                    <expandingTableRow :props="props" />
+                </template>
+            </q-table>
+        </div>
+    </template>
+    <template v-else>
+        <noResults />
+    </template>
 </template>
 
 <script setup>
 import { computed, ref } from "vue";
+import { api } from "boot/axios";
 import { metaDataStore } from "src/stores/metaDataStore.js";
 import { speechesDataStore } from "src/stores/speechesDataStore";
+import { downloadDataStore } from "src/stores/downloadDataStore";
 import expandingTableRow from "src/components/expandingTableRow.vue";
 import noResults from "src/components/noResults.vue";
 
 const metaStore = metaDataStore();
 const speechesStore = speechesDataStore();
+const downloadStore = downloadDataStore();
 
 const SpeechTable = ref(null);
 
 const pagination = computed({
-  get: () => speechesStore.pagination,
-  set: (value) => {
-    speechesStore.pagination = value;
-  },
+    get: () => speechesStore.pagination,
+    set: (value) => {
+        speechesStore.pagination = value;
+    },
 });
 
 const expandRow = (props) => {
-  props.expand = !props.expand;
+    props.expand = !props.expand;
 };
 
 const onRequest = async ({ pagination }) => {
-  if (!speechesStore.ticketId) return;
-  await speechesStore.fetchSpeechesPage({
-    page: pagination.page,
-    rowsPerPage: pagination.rowsPerPage,
-    sortBy: pagination.sortBy,
-    descending: pagination.descending,
-  });
+    if (!speechesStore.ticketId) return;
+    await speechesStore.fetchSpeechesPage({
+        page: pagination.page,
+        rowsPerPage: pagination.rowsPerPage,
+        sortBy: pagination.sortBy,
+        descending: pagination.descending,
+    });
 };
 
-// TODO: Implement download functionality once GET /speeches/download/{ticket_id} endpoint is added
-// const downloadCSV = async () => { ... };
-// const downloadExcel = async () => { ... };
+const downloadCSV = async () => {
+    if (!speechesStore.ticketId) return;
+    try {
+        const response = await api.get(
+            `/tools/speeches/download/${speechesStore.ticketId}`,
+            { params: { format: "csv" }, responseType: "blob" },
+        );
+        downloadStore.setupDownload("speeches.csv", response.data, "text/csv");
+    } catch (error) {
+        console.error("Error downloading speeches CSV:", error);
+    }
+};
+
+const downloadJSON = async () => {
+    if (!speechesStore.ticketId) return;
+    try {
+        const response = await api.get(
+            `/tools/speeches/download/${speechesStore.ticketId}`,
+            { params: { format: "json" }, responseType: "blob" },
+        );
+        downloadStore.setupDownload(
+            "speeches.json",
+            response.data,
+            "application/json",
+        );
+    } catch (error) {
+        console.error("Error downloading speeches JSON:", error);
+    }
+};
 
 const rows = computed(() =>
-  speechesStore.speechesData.map((speech, index) => ({
-    id: speech.speech_id,
-    unique_id: `${speechesStore.pagination.page}-${index}-${speech.speech_id}`,
-    protocol: speech.speech_name,
-    speaker: speech.name,
-    gender: speech.gender,
-    party: speech.party_abbrev,
-    party_full: speech.party,
-    source: speech.speech_link,
-    year: speech.year,
-    link: speech.link,
-  })),
+    speechesStore.speechesData.map((speech, index) => ({
+        id: speech.speech_id,
+        unique_id: `${speechesStore.pagination.page}-${index}-${speech.speech_id}`,
+        protocol: speech.speech_name,
+        speaker: speech.name,
+        gender: speech.gender,
+        party: speech.party_abbrev,
+        party_full: speech.party,
+        source: speech.speech_link,
+        year: speech.year,
+        link: speech.link,
+    })),
 );
 
 const columns = [
-  {
-    name: "protocol",
-    required: true,
-    label: "Anförande",
-    align: "left",
-    field: "protocol",
-    sortable: true,
-  },
-  {
-    name: "speaker",
-    required: true,
-    label: "Talare",
-    field: "speaker",
-    sortable: true,
-    align: "left",
-  },
-  {
-    name: "gender",
-    required: true,
-    label: "Kön",
-    field: "gender",
-    sortable: false,
-    align: "left",
-  },
-  {
-    name: "party",
-    required: true,
-    label: "Parti",
-    field: "party",
-    sortable: true,
-    align: "left",
-  },
-  {
-    name: "year",
-    required: true,
-    label: "År",
-    field: "year",
-    sortable: true,
-    align: "left",
-  },
+    {
+        name: "protocol",
+        required: true,
+        label: "Anförande",
+        align: "left",
+        field: "protocol",
+        sortable: true,
+    },
+    {
+        name: "speaker",
+        required: true,
+        label: "Talare",
+        field: "speaker",
+        sortable: true,
+        align: "left",
+    },
+    {
+        name: "gender",
+        required: true,
+        label: "Kön",
+        field: "gender",
+        sortable: false,
+        align: "left",
+    },
+    {
+        name: "party",
+        required: true,
+        label: "Parti",
+        field: "party",
+        sortable: true,
+        align: "left",
+    },
+    {
+        name: "year",
+        required: true,
+        label: "År",
+        field: "year",
+        sortable: true,
+        align: "left",
+    },
 ];
 </script>
 

--- a/src/i18n/en-US/index.js
+++ b/src/i18n/en-US/index.js
@@ -7,5 +7,6 @@ export default {
   kwicFetchError: "Could not load KWIC results.",
   accessibility: {
     loadingResults: "Loading results, please wait...",
+    ticketExpired: "The results have expired. Please submit a new search.",
   },
 };

--- a/src/i18n/sv/index.js
+++ b/src/i18n/sv/index.js
@@ -647,6 +647,7 @@ export default {
     noResults: "Inga resultat för sökningen.",
     noResultsTip:
       "Försök igen med ett annat sökord, eller andra filtreringsalternativ.",
+    ticketExpired: "Resultaten har gått ut. Vänligen gör en ny sökning.",
 
     errorMessage404: "Hoppsan, här fanns inget!",
     errorMessageButton: "Tillbaka till startsidan",

--- a/src/i18n/sv/index.js
+++ b/src/i18n/sv/index.js
@@ -178,6 +178,7 @@ export default {
   searchResult2ngram: "unika träffar.",
   downloadKWIC: "Ladda ner KWIC",
   downloadCSV: "Ladda ner CSV",
+  downloadJSON: "Ladda ner JSON",
   downloadExcel: "Ladda ner Excel",
   downloadSpeech: "Tal",
 

--- a/src/pages/SpeechesPage.vue
+++ b/src/pages/SpeechesPage.vue
@@ -3,7 +3,7 @@
     <q-item-label class="text-h6 q-pb-sm q-pt-none">{{
       $t("speechesIntroTitle")
     }}</q-item-label>
-    <div class="word-trends-intro lineHeight" v-html="formattedIntro"/>
+    <div class="word-trends-intro lineHeight" v-html="formattedIntro" />
   </q-card>
   <loadingIcon v-if="loading" size="100" />
   <div v-show="showData">
@@ -11,7 +11,7 @@
       <ShowData :filterSelections="'Speeches'" />
     </div>
     <div v-if="!loading" class="q-pb-xl q-px-md">
-      <speechDataTable type="speeches" />
+      <speechesTable />
     </div>
   </div>
 </template>
@@ -20,7 +20,7 @@
 import { ref, watchEffect, onMounted } from "vue";
 import { metaDataStore } from "src/stores/metaDataStore";
 import { speechesDataStore } from "src/stores/speechesDataStore.js";
-import speechDataTable from "src/components/speechDataTable.vue";
+import speechesTable from "src/components/speechesTable.vue";
 import ShowData from "src/components/ShowData.vue";
 import loadingIcon from "src/components/loadingIcon.vue";
 import i18n from "src/i18n/sv";
@@ -43,7 +43,7 @@ watchEffect(async () => {
   if (metaStore.submitEventSpeeches) {
     showData.value = false;
     loading.value = true;
-    await speechStore.getSpeechesResult();
+    await speechStore.getSpeechesTicketResult();
     setTimeout(() => {
       loading.value = false;
       showData.value = true;

--- a/src/pages/SpeechesPage.vue
+++ b/src/pages/SpeechesPage.vue
@@ -2,7 +2,7 @@
   <q-card flat class="q-px-md background q-pt-sm q-pb-md">
     <q-item-label class="text-h6 q-pb-sm q-pt-none">{{
       $t("speechesIntroTitle")
-    }}</q-item-label>
+      }}</q-item-label>
     <div class="word-trends-intro lineHeight" v-html="formattedIntro" />
   </q-card>
   <loadingIcon v-if="loading" size="100" />
@@ -33,8 +33,8 @@ const loading = ref(false);
 const showData = ref(false);
 
 onMounted(() => {
+  showData.value = true;
   if (speechStore.speechesData && speechStore.speechesData.length > 0) {
-    showData.value = true;
     loading.value = false;
   }
 });

--- a/src/pages/WordTrendsPage.vue
+++ b/src/pages/WordTrendsPage.vue
@@ -2,7 +2,7 @@
   <q-card flat class="q-px-md background q-pt-sm q-pb-md">
     <q-item-label class="text-h6 q-pb-sm q-pt-none">{{
       $t("wordTrendsIntroTitle")
-    }}</q-item-label>
+      }}</q-item-label>
     <div class="word-trends-intro lineHeight" v-html="formattedIntro"></div>
   </q-card>
 
@@ -88,12 +88,12 @@ watchEffect(async () => {
     loadingSpeeches.value = true;
     showData.value = false;
     showDataTable.value = false;
-    
+
     const textString = wtStore.generateStringOfSelected();
 
     // Start both API requests in parallel (don't await yet)
     const trendsPromise = wtStore.getWordTrendsResult(textString);
-    const speechesPromise = wtStore.getWordTrendsSpeeches(textString);
+    const speechesPromise = wtStore.getWordTrendsSpeechesTicket(textString);
 
     // Show trends chart/table as soon as trends data arrives (~2s)
     trendsPromise.then(() => {

--- a/src/pages/WordTrendsPage.vue
+++ b/src/pages/WordTrendsPage.vue
@@ -95,6 +95,8 @@ watchEffect(async () => {
     const trendsPromise = wtStore.getWordTrendsResult(textString);
     const speechesPromise = wtStore.getWordTrendsSpeechesTicket(textString);
 
+    showData.value = true;
+
     // Show trends chart/table as soon as trends data arrives (~2s)
     trendsPromise.then(() => {
       showDataTable.value = true;
@@ -107,7 +109,6 @@ watchEffect(async () => {
 
     // Show speeches table as soon as speeches data arrives (~30s)
     speechesPromise.then(() => {
-      showData.value = true;
       dataLoaded.value = true;
       loadingSpeeches.value = false;  // Speech tab ready!
     }).catch((error) => {

--- a/src/stores/kwicDataStore.js
+++ b/src/stores/kwicDataStore.js
@@ -5,6 +5,7 @@ import { metaDataStore } from "./metaDataStore";
 import { downloadDataStore } from "./downloadDataStore";
 import JSZip from "jszip";
 import ExcelJS from "exceljs";
+import i18n from "src/i18n/sv/index.js";
 
 const DEFAULT_ROWS_PER_PAGE = 10;
 const DEFAULT_SORT_BY = "protocol";
@@ -209,7 +210,7 @@ export const kwicDataStore = defineStore("kwicData", {
         return response.data;
       } catch (error) {
         if (error.response?.status === 404) {
-          this.errorMessage = "Sökresultaten har gått ut. Vänligen gör en ny sökning.";
+          this.errorMessage = i18n.accessibility.ticketExpired;
           this.resetTicketState();
         } else if (axios.isCancel(error)) {
           console.log("Request canceled", error.message);
@@ -282,7 +283,7 @@ export const kwicDataStore = defineStore("kwicData", {
         const response = await api.post(
           "/tools/kwic/query",
           this.buildKwicTicketPayload(normalizedSearch),
-          { cancelToken: this.cancelTokenSource.token }
+          { cancelToken: this.cancelTokenSource.token },
         );
 
         if (requestId !== this.requestSequence) {
@@ -337,7 +338,7 @@ export const kwicDataStore = defineStore("kwicData", {
       };
       const queryString = metaDataStore().getSelectedParamsAtSearch(
         "kwic",
-        additionalParams
+        additionalParams,
       );
       const response = await api.get(`${path}?${queryString}`);
 
@@ -396,9 +397,9 @@ export const kwicDataStore = defineStore("kwicData", {
           .map((obj) =>
             Object.keys(this.columnNames)
               .map(
-                (key) => `"${(obj[key] ?? "").toString().replace(/"/g, '""')}"`
+                (key) => `"${(obj[key] ?? "").toString().replace(/"/g, '""')}"`,
               )
-              .join(",")
+              .join(","),
           )
           .join("\n");
 

--- a/src/stores/speechesDataStore.js
+++ b/src/stores/speechesDataStore.js
@@ -66,7 +66,6 @@ export const speechesDataStore = defineStore("speechesData", {
       this.speechesData = [];
       this.totalHits = 0;
       this.totalPages = 0;
-      this.errorMessage = "";
       this.pagination = {
         ...this.pagination,
         page: 1,
@@ -172,9 +171,7 @@ export const speechesDataStore = defineStore("speechesData", {
 
       try {
         const queryString = metaDataStore().getSelectedParams();
-        const response = await api.post(
-          `/tools/speeches/query?${queryString}`,
-        );
+        const response = await api.post(`/tools/speeches/query?${queryString}`);
 
         if (requestId !== this.requestSequence) {
           return;

--- a/src/stores/speechesDataStore.js
+++ b/src/stores/speechesDataStore.js
@@ -2,6 +2,7 @@ import { defineStore } from "pinia";
 import { api } from "boot/axios";
 import { metaDataStore } from "./metaDataStore";
 import axios from "axios";
+import i18n from "src/i18n/sv/index.js";
 
 const DEFAULT_PAGE_SIZE = 50;
 const TICKET_POLL_INTERVAL_MS = 1000;
@@ -142,8 +143,7 @@ export const speechesDataStore = defineStore("speechesData", {
         return response.data;
       } catch (error) {
         if (error.response?.status === 404) {
-          this.errorMessage =
-            "Resultaten har gått ut. Vänligen gör en ny sökning.";
+          this.errorMessage = i18n.accessibility.ticketExpired;
           this.resetTicketState();
         } else if (axios.isCancel(error)) {
           console.log("Request canceled", error.message);

--- a/src/stores/speechesDataStore.js
+++ b/src/stores/speechesDataStore.js
@@ -1,14 +1,43 @@
 import { defineStore } from "pinia";
 import { api } from "boot/axios";
 import { metaDataStore } from "./metaDataStore";
+import axios from "axios";
+
+const DEFAULT_PAGE_SIZE = 50;
+const TICKET_POLL_INTERVAL_MS = 1000;
+const TICKET_POLL_MAX_ATTEMPTS = 120;
+
+const SORT_FIELD_MAP = {
+  speaker: "name",
+  party: "party_abbrev",
+  year: "year",
+  protocol: "document_name",
+};
 
 export const speechesDataStore = defineStore("speechesData", {
   state: () => ({
-    /* selected: metaDataStore().selected, */
     speechesData: [],
+    // Ticket-based pagination state
+    ticketId: null,
+    ticketStatus: null,
+    totalHits: 0,
+    totalPages: 0,
+    errorMessage: "",
+    isLoading: false,
+    isPageLoading: false,
+    requestSequence: 0,
+    pageRequestSequence: 0,
+    pagination: {
+      sortBy: "year",
+      descending: true,
+      page: 1,
+      rowsPerPage: DEFAULT_PAGE_SIZE,
+      rowsNumber: 0,
+    },
   }),
 
   actions: {
+    // Legacy method - kept for backward compatibility
     async getSpeechesResult() {
       try {
         const path = "/tools/speeches";
@@ -20,6 +49,7 @@ export const speechesDataStore = defineStore("speechesData", {
         console.error("Error fetching data:", error);
       }
     },
+
     async getSpeech(id) {
       try {
         const path = `/tools/speeches/${id}`;
@@ -30,5 +60,151 @@ export const speechesDataStore = defineStore("speechesData", {
       }
     },
 
+    resetTicketState() {
+      this.ticketId = null;
+      this.ticketStatus = null;
+      this.speechesData = [];
+      this.totalHits = 0;
+      this.totalPages = 0;
+      this.errorMessage = "";
+      this.pagination = {
+        ...this.pagination,
+        page: 1,
+        rowsNumber: 0,
+      };
+    },
+
+    async waitForTicketReady(requestId) {
+      for (let attempt = 0; attempt < TICKET_POLL_MAX_ATTEMPTS; attempt++) {
+        if (requestId !== this.requestSequence) {
+          return false;
+        }
+        await new Promise((resolve) =>
+          setTimeout(resolve, TICKET_POLL_INTERVAL_MS),
+        );
+        try {
+          const response = await api.get(
+            `/tools/speeches/status/${this.ticketId}`,
+          );
+          const status = response.data.status;
+          this.ticketStatus = status;
+          if (response.data.total_hits != null) {
+            this.totalHits = response.data.total_hits;
+          }
+          if (status === "ready") {
+            return true;
+          }
+          if (status === "error") {
+            this.errorMessage =
+              response.data.error || "Okänt fel vid hämtning av anföranden.";
+            return false;
+          }
+        } catch (error) {
+          console.error("Error polling speeches ticket status:", error);
+          return false;
+        }
+      }
+      this.errorMessage = "Tidsgränsen för sökningen uppnåddes.";
+      return false;
+    },
+
+    async fetchSpeechesPage({ page, rowsPerPage, sortBy, descending }) {
+      if (!this.ticketId) return;
+      const pageRequestId = ++this.pageRequestSequence;
+      this.isPageLoading = true;
+      const apiSortBy = SORT_FIELD_MAP[sortBy] || sortBy || "year";
+      const sortOrder = descending ? "desc" : "asc";
+      try {
+        const response = await api.get(
+          `/tools/speeches/page/${this.ticketId}`,
+          {
+            params: {
+              page,
+              page_size: rowsPerPage,
+              sort_by: apiSortBy,
+              sort_order: sortOrder,
+            },
+          },
+        );
+        if (pageRequestId !== this.pageRequestSequence) {
+          return;
+        }
+        this.speechesData = response.data.speech_list;
+        this.totalHits = response.data.total_hits;
+        this.totalPages = response.data.total_pages;
+        this.pagination = {
+          ...this.pagination,
+          page,
+          rowsPerPage,
+          sortBy,
+          descending,
+          rowsNumber: response.data.total_hits,
+        };
+        return response.data;
+      } catch (error) {
+        if (error.response?.status === 404) {
+          this.errorMessage =
+            "Resultaten har gått ut. Vänligen gör en ny sökning.";
+          this.resetTicketState();
+        } else if (axios.isCancel(error)) {
+          console.log("Request canceled", error.message);
+        } else {
+          this.errorMessage =
+            error?.response?.data?.detail ||
+            error?.message ||
+            "Kunde inte hämta anföranden";
+        }
+        console.error("Error fetching speeches page:", error);
+        return null;
+      } finally {
+        if (pageRequestId === this.pageRequestSequence) {
+          this.isPageLoading = false;
+        }
+      }
+    },
+
+    async getSpeechesTicketResult() {
+      const requestId = ++this.requestSequence;
+      this.pageRequestSequence = 0;
+      this.isLoading = true;
+      this.errorMessage = "";
+      this.resetTicketState();
+
+      try {
+        const queryString = metaDataStore().getSelectedParams();
+        const response = await api.post(
+          `/tools/speeches/query?${queryString}`,
+        );
+
+        if (requestId !== this.requestSequence) {
+          return;
+        }
+
+        this.ticketId = response.data.ticket_id;
+        this.ticketStatus = response.data.status;
+
+        const ready = await this.waitForTicketReady(requestId);
+        if (!ready || requestId !== this.requestSequence) {
+          return;
+        }
+
+        await this.fetchSpeechesPage({
+          page: 1,
+          rowsPerPage: this.pagination.rowsPerPage,
+          sortBy: this.pagination.sortBy,
+          descending: this.pagination.descending,
+        });
+      } catch (error) {
+        this.speechesData = [];
+        this.totalHits = 0;
+        this.totalPages = 0;
+        this.errorMessage = "Kunde inte hämta anföranden.";
+        console.error("Error fetching speeches (ticket):", error);
+      } finally {
+        if (requestId === this.requestSequence) {
+          this.isLoading = false;
+        }
+      }
+    },
   },
 });

--- a/src/stores/wordTrendsDataStore.js
+++ b/src/stores/wordTrendsDataStore.js
@@ -80,6 +80,10 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
       }
     },
 
+    /**
+     * @deprecated Use getWordTrendsSpeechesTicket() instead for server-side pagination
+     * Legacy method that fetches all speeches in a single request
+     */
     async getWordTrendsSpeeches(search) {
       try {
         const path = `/tools/word_trend_speeches/${search}`;
@@ -175,12 +179,16 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
         return response.data;
       } catch (error) {
         if (error.response?.status === 404) {
-          this.speechesErrorMessage = "Resultaten har gått ut. Vänligen gör en ny sökning.";
+          this.speechesErrorMessage =
+            "Resultaten har gått ut. Vänligen gör en ny sökning.";
           this.resetSpeechesTicketState();
         } else if (axios.isCancel(error)) {
           console.log("Request canceled", error.message);
         } else {
-          this.speechesErrorMessage = error?.response?.data?.detail || error?.message || "Kunde inte hämta anföranden";
+          this.speechesErrorMessage =
+            error?.response?.data?.detail ||
+            error?.message ||
+            "Kunde inte hämta anföranden";
         }
         console.error("Error fetching speeches page:", error);
         return null;

--- a/src/stores/wordTrendsDataStore.js
+++ b/src/stores/wordTrendsDataStore.js
@@ -127,7 +127,7 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
           if (response.data.total_hits != null) {
             this.speechesTotalHits = response.data.total_hits;
           }
-          if (status === "completed") {
+          if (status === "ready") {
             return true;
           }
           if (status === "error") {

--- a/src/stores/wordTrendsDataStore.js
+++ b/src/stores/wordTrendsDataStore.js
@@ -4,6 +4,7 @@ import { metaDataStore } from "./metaDataStore";
 import JSZip from "jszip";
 import ExcelJS from "exceljs";
 import { downloadDataStore } from "./downloadDataStore";
+import i18n from "src/i18n/sv/index.js";
 
 const DEFAULT_PAGE_SIZE = 50;
 const TICKET_POLL_INTERVAL_MS = 1000;
@@ -178,8 +179,7 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
         return response.data;
       } catch (error) {
         if (error.response?.status === 404) {
-          this.speechesErrorMessage =
-            "Resultaten har gått ut. Vänligen gör en ny sökning.";
+          this.speechesErrorMessage = i18n.accessibility.ticketExpired;
           this.resetSpeechesTicketState();
         } else if (axios.isCancel(error)) {
           console.log("Request canceled", error.message);

--- a/src/stores/wordTrendsDataStore.js
+++ b/src/stores/wordTrendsDataStore.js
@@ -102,7 +102,6 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
       this.speechesData = [];
       this.speechesTotalHits = 0;
       this.speechesTotalPages = 0;
-      this.speechesErrorMessage = "";
       this.speechesPagination = {
         ...this.speechesPagination,
         page: 1,


### PR DESCRIPTION
Enhance the speeches tool with server-side pagination using a ticket-based workflow, improving error handling for expired tickets. This update includes the addition of user-friendly Swedish error messages and ensures that expired tickets display the correct notification instead of misleading "no results" messages. The implementation aligns with existing patterns in KWIC and Word Trends tools, providing a consistent user experience across all tools. Manual testing is pending to finalize the deployment.