### PR TITLE
fix(download): use ticketed frontend download flows

### DIFF
--- a/src/components/speechesTable.vue
+++ b/src/components/speechesTable.vue
@@ -18,14 +18,14 @@
                 <q-btn-dropdown no-caps icon="download" class="text-grey-8 col-3" color="secondary"
                     :label="$t('downloadSpeech')" style="width: fit-content">
                     <q-list>
-                        <q-item clickable v-close-popup @click="downloadCSV">
+                        <q-item clickable v-close-popup @click="downloadCsvArchive">
                             <q-item-section>
-                                <q-item-label>{{ $t("downloadCSV") }}</q-item-label>
+                                <q-item-label>{{ $t("downloadSpeechCsvArchive") }}</q-item-label>
                             </q-item-section>
                         </q-item>
-                        <q-item clickable v-close-popup @click="downloadJSON">
+                        <q-item clickable v-close-popup @click="downloadJsonArchive">
                             <q-item-section>
-                                <q-item-label>{{ $t("downloadJSON") }}</q-item-label>
+                                <q-item-label>{{ $t("downloadSpeechJsonArchive") }}</q-item-label>
                             </q-item-section>
                         </q-item>
                     </q-list>
@@ -134,7 +134,7 @@ const onRequest = async ({ pagination }) => {
     });
 };
 
-const downloadCSV = async () => {
+const downloadCsvArchive = async () => {
     if (!speechesStore.ticketId) return;
     try {
         const response = await api.get(
@@ -149,11 +149,11 @@ const downloadCSV = async () => {
             response.data,
         );
     } catch (error) {
-        console.error("Error downloading speeches CSV:", error);
+        console.error("Error downloading speeches CSV archive:", error);
     }
 };
 
-const downloadJSON = async () => {
+const downloadJsonArchive = async () => {
     if (!speechesStore.ticketId) return;
     try {
         const response = await api.get(
@@ -168,7 +168,7 @@ const downloadJSON = async () => {
             response.data,
         );
     } catch (error) {
-        console.error("Error downloading speeches JSON:", error);
+        console.error("Error downloading speeches JSON archive:", error);
     }
 };
 

--- a/src/components/speechesTable.vue
+++ b/src/components/speechesTable.vue
@@ -141,7 +141,13 @@ const downloadCSV = async () => {
             `/tools/speeches/download/${speechesStore.ticketId}`,
             { params: { format: "csv" }, responseType: "blob" },
         );
-        downloadStore.setupDownload("speeches.csv", response.data, "text/csv");
+        downloadStore.setupDownload(
+            downloadStore.getFilenameFromDisposition(
+                response.headers,
+                `speeches_${speechesStore.ticketId}.zip`,
+            ),
+            response.data,
+        );
     } catch (error) {
         console.error("Error downloading speeches CSV:", error);
     }
@@ -155,9 +161,11 @@ const downloadJSON = async () => {
             { params: { format: "json" }, responseType: "blob" },
         );
         downloadStore.setupDownload(
-            "speeches.json",
+            downloadStore.getFilenameFromDisposition(
+                response.headers,
+                `speeches_${speechesStore.ticketId}.zip`,
+            ),
             response.data,
-            "application/json",
         );
     } catch (error) {
         console.error("Error downloading speeches JSON:", error);

--- a/src/i18n/en-US/index.js
+++ b/src/i18n/en-US/index.js
@@ -5,6 +5,8 @@ export default {
   failed: "Action failed",
   success: "Action was successful",
   kwicFetchError: "Could not load KWIC results.",
+  downloadSpeechCsvArchive: "Download CSV archive (.zip)",
+  downloadSpeechJsonArchive: "Download JSON archive (.zip)",
   accessibility: {
     loadingResults: "Loading results, please wait...",
     ticketExpired: "The results have expired. Please submit a new search.",

--- a/src/i18n/sv/index.js
+++ b/src/i18n/sv/index.js
@@ -181,6 +181,8 @@ export default {
   downloadKWIC: "Ladda ner KWIC",
   downloadCSV: "Ladda ner CSV",
   downloadJSON: "Ladda ner JSON",
+  downloadSpeechCsvArchive: "Ladda ner CSV-arkiv (.zip)",
+  downloadSpeechJsonArchive: "Ladda ner JSON-arkiv (.zip)",
   downloadExcel: "Ladda ner Excel",
   downloadSpeech: "Tal",
 

--- a/src/stores/downloadDataStore.js
+++ b/src/stores/downloadDataStore.js
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 import { api } from "boot/axios";
+import JSZip from "jszip";
 import i18n from "src/i18n/sv/index.js";
 import { metaDataStore } from "./metaDataStore";
 
@@ -42,6 +43,26 @@ export const downloadDataStore = defineStore("downloadData", {
       }, 1000);
     },
 
+    getFilenameFromDisposition(headers, fallbackName) {
+      const disposition = headers?.["content-disposition"];
+      const match = disposition?.match(/filename="?([^";]+)"?/i);
+      return match?.[1] || fallbackName;
+    },
+
+    async extractJsonPayloadFromZip(blob) {
+      const archive = await JSZip.loadAsync(blob);
+      const payloadName = Object.keys(archive.files).find(
+        (name) => name.endsWith(".json") && name !== "manifest.json",
+      );
+
+      if (!payloadName) {
+        return [];
+      }
+
+      const payload = await archive.file(payloadName).async("string");
+      return JSON.parse(payload);
+    },
+
     async downloadCurrentSpeechText(text, currentMetadata) {
       try {
         const filename = this.formatFileName(currentMetadata);
@@ -74,15 +95,17 @@ export const downloadDataStore = defineStore("downloadData", {
 
     async downloadSpeechesZipByTicket(ticketId) {
       try {
-        const response = await api.post(
-          `tools/speeches/download?ticket_id=${encodeURIComponent(ticketId)}`,
-          null,
+        const response = await api.get(
+          `/tools/speeches/archive/${encodeURIComponent(ticketId)}`,
           {
             responseType: "blob",
-          }
+          },
         );
 
-        this.setupDownload("tal.zip", new Blob([response.data]));
+        this.setupDownload(
+          this.getFilenameFromDisposition(response.headers, `speeches_${ticketId}.zip`),
+          response.data,
+        );
       } catch (error) {
         console.error("Error fetching ticket download:", error);
       }

--- a/src/stores/downloadDataStore.js
+++ b/src/stores/downloadDataStore.js
@@ -43,24 +43,68 @@ export const downloadDataStore = defineStore("downloadData", {
       }, 1000);
     },
 
+    sanitizeDownloadFilename(filename) {
+      return filename?.replace(/[\\/]/g, "_");
+    },
+
+    decodeRfc5987Value(value) {
+      const match = value?.match(/^([^']*)'([^']*)'(.*)$/);
+      const encodedValue = match ? match[3] : value;
+
+      try {
+        return decodeURIComponent(encodedValue);
+      } catch {
+        return encodedValue;
+      }
+    },
+
     getFilenameFromDisposition(headers, fallbackName) {
       const disposition = headers?.["content-disposition"];
-      const match = disposition?.match(/filename="?([^";]+)"?/i);
-      return match?.[1] || fallbackName;
+
+      const extendedMatch = disposition?.match(/filename\*\s*=\s*([^;]+)/i);
+      if (extendedMatch?.[1]) {
+        const extendedFilename = this.decodeRfc5987Value(
+          extendedMatch[1].trim().replace(/^"(.*)"$/, "$1"),
+        );
+        const sanitizedExtendedFilename = this.sanitizeDownloadFilename(
+          extendedFilename,
+        );
+
+        if (sanitizedExtendedFilename) {
+          return sanitizedExtendedFilename;
+        }
+      }
+
+      const match = disposition?.match(
+        /filename\s*=\s*"([^"]+)"|filename\s*=\s*([^;]+)/i,
+      );
+      const filename = match?.[1] || match?.[2]?.trim();
+
+      return this.sanitizeDownloadFilename(filename || fallbackName) || fallbackName;
     },
 
     async extractJsonPayloadFromZip(blob) {
-      const archive = await JSZip.loadAsync(blob);
-      const payloadName = Object.keys(archive.files).find(
-        (name) => name.endsWith(".json") && name !== "manifest.json",
-      );
+      try {
+        const archive = await JSZip.loadAsync(blob);
+        const payloadName = Object.keys(archive.files).find(
+          (name) => name.endsWith(".json") && name !== "manifest.json",
+        );
 
-      if (!payloadName) {
+        if (!payloadName) {
+          return [];
+        }
+
+        const payloadFile = archive.file(payloadName);
+        if (!payloadFile) {
+          return [];
+        }
+
+        const payload = await payloadFile.async("string");
+        return JSON.parse(payload);
+      } catch (error) {
+        console.error("Error extracting JSON payload from zip:", error);
         return [];
       }
-
-      const payload = await archive.file(payloadName).async("string");
-      return JSON.parse(payload);
     },
 
     async downloadCurrentSpeechText(text, currentMetadata) {

--- a/src/stores/kwicDataStore.js
+++ b/src/stores/kwicDataStore.js
@@ -331,10 +331,13 @@ export const kwicDataStore = defineStore("kwicData", {
 
     async fetchKwicExportData() {
       if (this.useTicketFlow && this.ticketId) {
-        const response = await api.get(`/tools/kwic/download/${this.ticketId}`, {
-          params: { format: "json" },
-          responseType: "blob",
-        });
+        const response = await api.get(
+          `/tools/kwic/download/${this.ticketId}`,
+          {
+            params: { format: "json" },
+            responseType: "blob",
+          },
+        );
         return downloadDataStore().extractJsonPayloadFromZip(response.data);
       }
 
@@ -361,7 +364,11 @@ export const kwicDataStore = defineStore("kwicData", {
     },
 
     async getExportRows() {
-      return this.fetchKwicExportData();
+      if (this.useTicketFlow && this.ticketId) {
+        return this.fetchKwicExportData();
+      }
+
+      return this.kwicData || [];
     },
 
     async downloadKWICTableExcel(selectedMetadata) {

--- a/src/stores/kwicDataStore.js
+++ b/src/stores/kwicDataStore.js
@@ -330,6 +330,14 @@ export const kwicDataStore = defineStore("kwicData", {
     },
 
     async fetchKwicExportData() {
+      if (this.useTicketFlow && this.ticketId) {
+        const response = await api.get(`/tools/kwic/download/${this.ticketId}`, {
+          params: { format: "json" },
+          responseType: "blob",
+        });
+        return downloadDataStore().extractJsonPayloadFromZip(response.data);
+      }
+
       const normalizedSearch = this.normalizeSearch(this.searchText);
 
       if (!normalizedSearch) {
@@ -353,11 +361,7 @@ export const kwicDataStore = defineStore("kwicData", {
     },
 
     async getExportRows() {
-      if (this.useTicketFlow && this.ticketId) {
-        return this.fetchKwicExportData();
-      }
-
-      return this.kwicData;
+      return this.fetchKwicExportData();
     },
 
     async downloadKWICTableExcel(selectedMetadata) {

--- a/src/stores/wordTrendsDataStore.js
+++ b/src/stores/wordTrendsDataStore.js
@@ -260,7 +260,10 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
         { params: { format: "csv" }, responseType: "blob" },
       );
       downloadDataStore().setupDownload(
-        "word_trend_speeches.csv",
+        downloadDataStore().getFilenameFromDisposition(
+          response.headers,
+          `word_trend_speeches_${this.ticketId}.zip`,
+        ),
         response.data,
       );
     },
@@ -269,9 +272,11 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
       if (!this.ticketId) return;
       const response = await api.get(
         `/tools/word_trend_speeches/download/${this.ticketId}`,
-        { params: { format: "json" } },
+        { params: { format: "json" }, responseType: "blob" },
       );
-      const speechList = response.data.speech_list || [];
+      const speechList = await downloadDataStore().extractJsonPayloadFromZip(
+        response.data,
+      );
       if (speechList.length === 0) return;
       const headers = [
         "year",

--- a/src/stores/wordTrendsDataStore.js
+++ b/src/stores/wordTrendsDataStore.js
@@ -270,38 +270,53 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
 
     async downloadSpeechesExcel() {
       if (!this.ticketId) return;
-      const response = await api.get(
-        `/tools/word_trend_speeches/download/${this.ticketId}`,
-        { params: { format: "json" }, responseType: "blob" },
-      );
-      const speechList = await downloadDataStore().extractJsonPayloadFromZip(
-        response.data,
-      );
-      if (speechList.length === 0) return;
-      const headers = [
-        "year",
-        "name",
-        "party_abbrev",
-        "document_name",
-        "node_word",
-      ];
-      const data = speechList.map((row) => {
-        const newObj = {};
-        headers.forEach((key) => {
-          newObj[key] = row[key] ?? "";
+      this.speechesErrorMessage = "";
+
+      try {
+        const response = await api.get(
+          `/tools/word_trend_speeches/download/${this.ticketId}`,
+          { params: { format: "json" }, responseType: "blob" },
+        );
+        const speechList = await downloadDataStore().extractJsonPayloadFromZip(
+          response.data,
+        );
+        if (speechList.length === 0) return;
+        const headers = [
+          "year",
+          "name",
+          "party_abbrev",
+          "document_name",
+          "node_word",
+        ];
+        const data = speechList.map((row) => {
+          const newObj = {};
+          headers.forEach((key) => {
+            newObj[key] = row[key] ?? "";
+          });
+          return newObj;
         });
-        return newObj;
-      });
-      const workbook = new ExcelJS.Workbook();
-      const worksheet = workbook.addWorksheet("Sheet1");
-      worksheet.columns = headers.map((h) => ({ header: h, key: h }));
-      data.forEach((row) => worksheet.addRow(row));
-      const buffer = await workbook.xlsx.writeBuffer();
-      const zip = new JSZip();
-      zip.file("word_trend_speeches.xlsx", buffer);
-      zip.generateAsync({ type: "blob" }).then((content) => {
-        downloadDataStore().setupDownload("word_trend_speeches.zip", content);
-      });
+        const workbook = new ExcelJS.Workbook();
+        const worksheet = workbook.addWorksheet("Sheet1");
+        worksheet.columns = headers.map((h) => ({ header: h, key: h }));
+        data.forEach((row) => worksheet.addRow(row));
+        const buffer = await workbook.xlsx.writeBuffer();
+        const zip = new JSZip();
+        zip.file("word_trend_speeches.xlsx", buffer);
+        zip.generateAsync({ type: "blob" }).then((content) => {
+          downloadDataStore().setupDownload("word_trend_speeches.zip", content);
+        });
+      } catch (error) {
+        if (error.response?.status === 404) {
+          this.speechesErrorMessage = i18n.accessibility.ticketExpired;
+          this.resetSpeechesTicketState();
+        } else {
+          this.speechesErrorMessage =
+            error?.response?.data?.detail ||
+            error?.message ||
+            "Kunde inte hämta anföranden.";
+        }
+        console.error("Error downloading word trend speeches Excel:", error);
+      }
     },
 
     async getWordHits(search) {


### PR DESCRIPTION
## Summary

Aligns download behavior with the ticketed backend flows for KWIC, speeches, and word-trend speeches.

Refs humlab-swedeb/swedeb-api#331

## What changed

- switched KWIC table export to download from the ticket artifact instead of re-querying the legacy KWIC endpoint
- switched ticket-derived speech ZIP downloads to the dedicated ticket archive endpoint
- fixed speeches and word-trend speeches download handling so ticketed responses are treated as ZIP files
- added shared helpers for extracting filenames from response headers and reading zipped JSON payloads when needed for Excel generation

## Why

Several frontend download actions were still using legacy-style interfaces even after the search results had moved to ticketed flows. That caused inconsistent behavior and incorrect assumptions about response formats.

## Validation

- `pnpm lint`