### PR TITLE
feat(download): add non-blocking feedback

### DIFF
--- a/src/components/kwicDataTable.vue
+++ b/src/components/kwicDataTable.vue
@@ -12,19 +12,28 @@
       <q-btn-dropdown no-caps icon="download" class="text-grey-8 col-3" color="secondary" :label="$t('downloadKWIC')"
         style="width: fit-content">
         <q-list>
-          <q-item clickable v-close-popup @click="downloadKWICTableAsCSV">
+          <q-item clickable v-close-popup :disable="isDownloadActive(downloadKeys.csv)" @click="downloadKWICTableAsCSV">
             <q-item-section>
-              <q-item-label>{{ $t("downloadCSV") }}</q-item-label>
+              <q-item-label class="row items-center no-wrap">
+                <q-spinner-tail v-if="isDownloadActive(downloadKeys.csv)" size="16px" class="q-mr-sm" />
+                {{ $t("downloadCSV") }}
+              </q-item-label>
             </q-item-section>
           </q-item>
-          <q-item clickable v-close-popup @click="downloadKWICTableAsExcel">
+          <q-item clickable v-close-popup :disable="isDownloadActive(downloadKeys.excel)" @click="downloadKWICTableAsExcel">
             <q-item-section>
-              <q-item-label>{{ $t("downloadExcel") }}</q-item-label>
+              <q-item-label class="row items-center no-wrap">
+                <q-spinner-tail v-if="isDownloadActive(downloadKeys.excel)" size="16px" class="q-mr-sm" />
+                {{ $t("downloadExcel") }}
+              </q-item-label>
             </q-item-section>
           </q-item>
-          <q-item clickable v-close-popup @click="downloadKWICAsSpeeches">
+          <q-item clickable v-close-popup :disable="isDownloadActive(downloadKeys.speeches)" @click="downloadKWICAsSpeeches">
             <q-item-section>
-              <q-item-label>{{ $t("downloadSpeech") }}</q-item-label>
+              <q-item-label class="row items-center no-wrap">
+                <q-spinner-tail v-if="isDownloadActive(downloadKeys.speeches)" size="16px" class="q-mr-sm" />
+                {{ $t("downloadSpeech") }}
+              </q-item-label>
             </q-item-section>
           </q-item>
         </q-list>
@@ -112,6 +121,12 @@ const metaStore = metaDataStore();
 const kwicStore = kwicDataStore();
 const downloadStore = downloadDataStore();
 
+const downloadKeys = {
+  csv: "kwic-csv",
+  excel: "kwic-excel",
+  speeches: "kwic-speeches",
+};
+
 const KWICTable = ref(null);
 
 const pagination = computed({
@@ -152,22 +167,37 @@ const getParamString = () => {
   return metaStore.selectedMetadataToText("kwic");
 };
 
+const isDownloadActive = (downloadKey) =>
+  downloadStore.isDownloadActive(downloadKey);
+
 const downloadKWICTableAsExcel = async () => {
-  await kwicStore.downloadKWICTableExcel(getParamString());
+  await downloadStore.runTrackedDownload(downloadKeys.excel, () =>
+    kwicStore.downloadKWICTableExcel(getParamString()), {
+    getErrorMessage: () => kwicStore.errorMessage,
+  });
 };
 
 const downloadKWICTableAsCSV = async () => {
-  await kwicStore.downloadKWICTableCSV(getParamString());
+  await downloadStore.runTrackedDownload(downloadKeys.csv, () =>
+    kwicStore.downloadKWICTableCSV(getParamString()), {
+    getErrorMessage: () => kwicStore.errorMessage,
+  });
 };
 
-const downloadKWICAsSpeeches = () => {
+const downloadKWICAsSpeeches = async () => {
   if (kwicStore.useTicketFlow && kwicStore.ticketId) {
-    downloadStore.downloadSpeechesZipByTicket(kwicStore.ticketId);
+    await downloadStore.runTrackedDownload(downloadKeys.speeches, () =>
+      downloadStore.downloadSpeechesZipByTicket(kwicStore.ticketId), {
+      getErrorMessage: () => kwicStore.errorMessage,
+    });
     return;
   }
 
   const allIds = rows.value.map((row) => row.id);
-  downloadStore.downloadSpeechesZip(allIds);
+  await downloadStore.runTrackedDownload(downloadKeys.speeches, () =>
+    downloadStore.downloadSpeechesZip(allIds), {
+    getErrorMessage: () => kwicStore.errorMessage,
+  });
 };
 
 const rows = computed(() =>

--- a/src/components/speechesTable.vue
+++ b/src/components/speechesTable.vue
@@ -18,14 +18,20 @@
                 <q-btn-dropdown no-caps icon="download" class="text-grey-8 col-3" color="secondary"
                     :label="$t('downloadSpeech')" style="width: fit-content">
                     <q-list>
-                        <q-item clickable v-close-popup @click="downloadCsvArchive">
+                        <q-item clickable v-close-popup :disable="isDownloadActive(downloadKeys.csv)" @click="downloadCsvArchive">
                             <q-item-section>
-                                <q-item-label>{{ $t("downloadSpeechCsvArchive") }}</q-item-label>
+                                <q-item-label class="row items-center no-wrap">
+                                    <q-spinner-tail v-if="isDownloadActive(downloadKeys.csv)" size="16px" class="q-mr-sm" />
+                                    {{ $t("downloadSpeechCsvArchive") }}
+                                </q-item-label>
                             </q-item-section>
                         </q-item>
-                        <q-item clickable v-close-popup @click="downloadJsonArchive">
+                        <q-item clickable v-close-popup :disable="isDownloadActive(downloadKeys.json)" @click="downloadJsonArchive">
                             <q-item-section>
-                                <q-item-label>{{ $t("downloadSpeechJsonArchive") }}</q-item-label>
+                                <q-item-label class="row items-center no-wrap">
+                                    <q-spinner-tail v-if="isDownloadActive(downloadKeys.json)" size="16px" class="q-mr-sm" />
+                                    {{ $t("downloadSpeechJsonArchive") }}
+                                </q-item-label>
                             </q-item-section>
                         </q-item>
                     </q-list>
@@ -90,6 +96,7 @@
 <script setup>
 import { computed, ref } from "vue";
 import { api } from "boot/axios";
+import i18n from "src/i18n/sv/index.js";
 import { metaDataStore } from "src/stores/metaDataStore.js";
 import { speechesDataStore } from "src/stores/speechesDataStore";
 import { downloadDataStore } from "src/stores/downloadDataStore";
@@ -100,6 +107,11 @@ import noResults from "src/components/noResults.vue";
 const metaStore = metaDataStore();
 const speechesStore = speechesDataStore();
 const downloadStore = downloadDataStore();
+
+const downloadKeys = {
+    csv: "speeches-archive-csv",
+    json: "speeches-archive-json",
+};
 
 const SpeechTable = ref(null);
 
@@ -134,42 +146,52 @@ const onRequest = async ({ pagination }) => {
     });
 };
 
-const downloadCsvArchive = async () => {
+const isDownloadActive = (downloadKey) =>
+    downloadStore.isDownloadActive(downloadKey);
+
+const downloadArchive = async (downloadKey, format) => {
     if (!speechesStore.ticketId) return;
-    try {
-        const response = await api.get(
-            `/tools/speeches/download/${speechesStore.ticketId}`,
-            { params: { format: "csv" }, responseType: "blob" },
-        );
-        downloadStore.setupDownload(
-            downloadStore.getFilenameFromDisposition(
-                response.headers,
-                `speeches_${speechesStore.ticketId}.zip`,
-            ),
-            response.data,
-        );
-    } catch (error) {
-        console.error("Error downloading speeches CSV archive:", error);
-    }
+
+    await downloadStore.runTrackedDownload(downloadKey, async () => {
+        speechesStore.errorMessage = "";
+
+        try {
+            const response = await api.get(
+                `/tools/speeches/download/${speechesStore.ticketId}`,
+                { params: { format }, responseType: "blob" },
+            );
+            downloadStore.setupDownload(
+                downloadStore.getFilenameFromDisposition(
+                    response.headers,
+                    `speeches_${speechesStore.ticketId}.zip`,
+                ),
+                response.data,
+            );
+            return true;
+        } catch (error) {
+            if (error.response?.status === 404) {
+                speechesStore.errorMessage = i18n.accessibility.ticketExpired;
+                speechesStore.resetTicketState();
+            } else {
+                speechesStore.errorMessage = downloadStore.getDownloadErrorMessage(
+                    error,
+                    "Kunde inte hämta anföranden.",
+                );
+            }
+            console.error(`Error downloading speeches ${format} archive:`, error);
+            return false;
+        }
+    }, {
+        getErrorMessage: () => speechesStore.errorMessage,
+    });
+};
+
+const downloadCsvArchive = async () => {
+    await downloadArchive(downloadKeys.csv, "csv");
 };
 
 const downloadJsonArchive = async () => {
-    if (!speechesStore.ticketId) return;
-    try {
-        const response = await api.get(
-            `/tools/speeches/download/${speechesStore.ticketId}`,
-            { params: { format: "json" }, responseType: "blob" },
-        );
-        downloadStore.setupDownload(
-            downloadStore.getFilenameFromDisposition(
-                response.headers,
-                `speeches_${speechesStore.ticketId}.zip`,
-            ),
-            response.data,
-        );
-    } catch (error) {
-        console.error("Error downloading speeches JSON archive:", error);
-    }
+    await downloadArchive(downloadKeys.json, "json");
 };
 
 const rows = computed(() =>

--- a/src/components/wordTrendsSpeechTable.vue
+++ b/src/components/wordTrendsSpeechTable.vue
@@ -18,14 +18,20 @@
         <q-btn-dropdown no-caps icon="download" class="text-grey-8 col-3" color="secondary"
           :label="$t('downloadSpeech')" style="width: fit-content">
           <q-list>
-            <q-item clickable v-close-popup @click="downloadCSV">
+            <q-item clickable v-close-popup :disable="isDownloadActive(downloadKeys.csv)" @click="downloadCSV">
               <q-item-section>
-                <q-item-label>{{ $t("downloadCSV") }}</q-item-label>
+                <q-item-label class="row items-center no-wrap">
+                  <q-spinner-tail v-if="isDownloadActive(downloadKeys.csv)" size="16px" class="q-mr-sm" />
+                  {{ $t("downloadCSV") }}
+                </q-item-label>
               </q-item-section>
             </q-item>
-            <q-item clickable v-close-popup @click="downloadExcel">
+            <q-item clickable v-close-popup :disable="isDownloadActive(downloadKeys.excel)" @click="downloadExcel">
               <q-item-section>
-                <q-item-label>{{ $t("downloadExcel") }}</q-item-label>
+                <q-item-label class="row items-center no-wrap">
+                  <q-spinner-tail v-if="isDownloadActive(downloadKeys.excel)" size="16px" class="q-mr-sm" />
+                  {{ $t("downloadExcel") }}
+                </q-item-label>
               </q-item-section>
             </q-item>
           </q-list>
@@ -89,14 +95,21 @@
 
 <script setup>
 import { computed, ref } from "vue";
+import { downloadDataStore } from "src/stores/downloadDataStore";
 import { metaDataStore } from "src/stores/metaDataStore.js";
 import { wordTrendsDataStore } from "src/stores/wordTrendsDataStore";
 import expandingTableRow from "src/components/expandingTableRow.vue";
 import loadingIcon from "src/components/loadingIcon.vue";
 import noResults from "src/components/noResults.vue";
 
+const downloadStore = downloadDataStore();
 const metaStore = metaDataStore();
 const wtStore = wordTrendsDataStore();
+
+const downloadKeys = {
+  csv: "word-trends-speeches-csv",
+  excel: "word-trends-speeches-excel",
+};
 
 const SpeechTable = ref(null);
 
@@ -131,12 +144,21 @@ const onRequest = async ({ pagination }) => {
   });
 };
 
+const isDownloadActive = (downloadKey) =>
+  downloadStore.isDownloadActive(downloadKey);
+
 const downloadCSV = async () => {
-  await wtStore.downloadSpeechesCSV();
+  await downloadStore.runTrackedDownload(downloadKeys.csv, () =>
+    wtStore.downloadSpeechesCSV(), {
+    getErrorMessage: () => wtStore.speechesErrorMessage,
+  });
 };
 
 const downloadExcel = async () => {
-  await wtStore.downloadSpeechesExcel();
+  await downloadStore.runTrackedDownload(downloadKeys.excel, () =>
+    wtStore.downloadSpeechesExcel(), {
+    getErrorMessage: () => wtStore.speechesErrorMessage,
+  });
 };
 
 const rows = computed(() =>

--- a/src/i18n/en-US/index.js
+++ b/src/i18n/en-US/index.js
@@ -7,6 +7,11 @@ export default {
   kwicFetchError: "Could not load KWIC results.",
   downloadSpeechCsvArchive: "Download CSV archive (.zip)",
   downloadSpeechJsonArchive: "Download JSON archive (.zip)",
+  downloadFeedback: {
+    preparing: "Preparing download...",
+    success: "The download has started.",
+    error: "Could not start the download.",
+  },
   accessibility: {
     loadingResults: "Loading results, please wait...",
     ticketExpired: "The results have expired. Please submit a new search.",

--- a/src/i18n/sv/index.js
+++ b/src/i18n/sv/index.js
@@ -185,6 +185,11 @@ export default {
   downloadSpeechJsonArchive: "Ladda ner JSON-arkiv (.zip)",
   downloadExcel: "Ladda ner Excel",
   downloadSpeech: "Tal",
+  downloadFeedback: {
+    preparing: "Förbereder nedladdning...",
+    success: "Nedladdningen har startat.",
+    error: "Kunde inte starta nedladdningen.",
+  },
 
   kwicLable: {
     left_word: "Vänster",

--- a/src/stores/downloadDataStore.js
+++ b/src/stores/downloadDataStore.js
@@ -37,11 +37,9 @@ export const downloadDataStore = defineStore("downloadData", {
       return {
         preparing:
           i18n.downloadFeedback?.preparing || "Förbereder nedladdning...",
-        success:
-          i18n.downloadFeedback?.success || "Nedladdningen har startat.",
+        success: i18n.downloadFeedback?.success || "Nedladdningen har startat.",
         error:
-          i18n.downloadFeedback?.error ||
-          "Kunde inte starta nedladdningen.",
+          i18n.downloadFeedback?.error || "Kunde inte starta nedladdningen.",
       };
     },
 
@@ -66,45 +64,60 @@ export const downloadDataStore = defineStore("downloadData", {
         return optionErrorMessage || messages.error;
       };
 
+      let dismissPreparingNotify = null;
+      let taskError = null;
+      let wasSuccessful = false;
+
       this.setDownloadActive(downloadKey, true);
-      Notify.create({
+      dismissPreparingNotify = Notify.create({
         spinner: true,
         message: preparingMessage,
-        timeout: 1200,
+        timeout: 0,
         position: "top",
       });
 
       try {
         const result = await task();
-
-        if (result === false) {
-          Notify.create({
-            type: "negative",
-            message: resolveErrorMessage(),
-            timeout: 3000,
-            position: "top",
-          });
-          return false;
-        }
-
-        Notify.create({
-          type: "positive",
-          message: successMessage,
-          timeout: 1500,
-          position: "top",
-        });
-        return true;
+        wasSuccessful = result !== false;
       } catch (error) {
+        taskError = error;
+      } finally {
+        if (typeof dismissPreparingNotify === "function") {
+          dismissPreparingNotify();
+        }
+        this.setDownloadActive(downloadKey, false);
+      }
+
+      if (taskError) {
         Notify.create({
           type: "negative",
-          message: this.getDownloadErrorMessage(error, resolveErrorMessage()),
+          message: this.getDownloadErrorMessage(
+            taskError,
+            resolveErrorMessage(),
+          ),
           timeout: 3000,
           position: "top",
         });
         return false;
-      } finally {
-        this.setDownloadActive(downloadKey, false);
       }
+
+      if (!wasSuccessful) {
+        Notify.create({
+          type: "negative",
+          message: resolveErrorMessage(),
+          timeout: 3000,
+          position: "top",
+        });
+        return false;
+      }
+
+      Notify.create({
+        type: "positive",
+        message: successMessage,
+        timeout: 1500,
+        position: "top",
+      });
+      return true;
     },
 
     formatProps(currentProps) {
@@ -167,9 +180,8 @@ export const downloadDataStore = defineStore("downloadData", {
         const extendedFilename = this.decodeRfc5987Value(
           extendedMatch[1].trim().replace(/^"(.*)"$/, "$1"),
         );
-        const sanitizedExtendedFilename = this.sanitizeDownloadFilename(
-          extendedFilename,
-        );
+        const sanitizedExtendedFilename =
+          this.sanitizeDownloadFilename(extendedFilename);
 
         if (sanitizedExtendedFilename) {
           return sanitizedExtendedFilename;
@@ -181,7 +193,9 @@ export const downloadDataStore = defineStore("downloadData", {
       );
       const filename = match?.[1] || match?.[2]?.trim();
 
-      return this.sanitizeDownloadFilename(filename || fallbackName) || fallbackName;
+      return (
+        this.sanitizeDownloadFilename(filename || fallbackName) || fallbackName
+      );
     },
 
     async extractJsonPayloadFromZip(blob) {
@@ -250,7 +264,10 @@ export const downloadDataStore = defineStore("downloadData", {
         );
 
         this.setupDownload(
-          this.getFilenameFromDisposition(response.headers, `speeches_${ticketId}.zip`),
+          this.getFilenameFromDisposition(
+            response.headers,
+            `speeches_${ticketId}.zip`,
+          ),
           response.data,
         );
         return true;

--- a/src/stores/downloadDataStore.js
+++ b/src/stores/downloadDataStore.js
@@ -1,11 +1,112 @@
 import { defineStore } from "pinia";
 import { api } from "boot/axios";
 import JSZip from "jszip";
+import { Notify } from "quasar";
 import i18n from "src/i18n/sv/index.js";
 import { metaDataStore } from "./metaDataStore";
 
 export const downloadDataStore = defineStore("downloadData", {
+  state: () => ({
+    activeDownloads: {},
+  }),
+
   actions: {
+    isDownloadActive(downloadKey) {
+      return Boolean(this.activeDownloads[downloadKey]);
+    },
+
+    setDownloadActive(downloadKey, isActive) {
+      if (!downloadKey) {
+        return;
+      }
+
+      if (isActive) {
+        this.activeDownloads = {
+          ...this.activeDownloads,
+          [downloadKey]: true,
+        };
+        return;
+      }
+
+      const nextActiveDownloads = { ...this.activeDownloads };
+      delete nextActiveDownloads[downloadKey];
+      this.activeDownloads = nextActiveDownloads;
+    },
+
+    getDownloadFeedbackMessages() {
+      return {
+        preparing:
+          i18n.downloadFeedback?.preparing || "Förbereder nedladdning...",
+        success:
+          i18n.downloadFeedback?.success || "Nedladdningen har startat.",
+        error:
+          i18n.downloadFeedback?.error ||
+          "Kunde inte starta nedladdningen.",
+      };
+    },
+
+    getDownloadErrorMessage(error, fallbackMessage) {
+      return error?.response?.data?.detail || error?.message || fallbackMessage;
+    },
+
+    async runTrackedDownload(downloadKey, task, options = {}) {
+      if (!downloadKey || this.isDownloadActive(downloadKey)) {
+        return false;
+      }
+
+      const messages = this.getDownloadFeedbackMessages();
+      const preparingMessage = options.preparingMessage || messages.preparing;
+      const successMessage = options.successMessage || messages.success;
+      const resolveErrorMessage = () => {
+        const optionErrorMessage =
+          typeof options.getErrorMessage === "function"
+            ? options.getErrorMessage()
+            : options.errorMessage;
+
+        return optionErrorMessage || messages.error;
+      };
+
+      this.setDownloadActive(downloadKey, true);
+      Notify.create({
+        spinner: true,
+        message: preparingMessage,
+        timeout: 1200,
+        position: "top",
+      });
+
+      try {
+        const result = await task();
+
+        if (result === false) {
+          Notify.create({
+            type: "negative",
+            message: resolveErrorMessage(),
+            timeout: 3000,
+            position: "top",
+          });
+          return false;
+        }
+
+        Notify.create({
+          type: "positive",
+          message: successMessage,
+          timeout: 1500,
+          position: "top",
+        });
+        return true;
+      } catch (error) {
+        Notify.create({
+          type: "negative",
+          message: this.getDownloadErrorMessage(error, resolveErrorMessage()),
+          timeout: 3000,
+          position: "top",
+        });
+        return false;
+      } finally {
+        this.setDownloadActive(downloadKey, false);
+      }
+    },
+
     formatProps(currentProps) {
       const speaker = `Talare: ${currentProps.speaker}`;
       const hit = `Sökord ${currentProps.node_word}`;
@@ -132,8 +233,10 @@ export const downloadDataStore = defineStore("downloadData", {
         });
 
         this.setupDownload("tal.zip", new Blob([response.data]));
+        return true;
       } catch (error) {
         console.error("Error fetching data for download:", error);
+        return false;
       }
     },
 
@@ -150,8 +253,10 @@ export const downloadDataStore = defineStore("downloadData", {
           this.getFilenameFromDisposition(response.headers, `speeches_${ticketId}.zip`),
           response.data,
         );
+        return true;
       } catch (error) {
         console.error("Error fetching ticket download:", error);
+        return false;
       }
     },
   },

--- a/src/stores/kwicDataStore.js
+++ b/src/stores/kwicDataStore.js
@@ -372,9 +372,17 @@ export const kwicDataStore = defineStore("kwicData", {
     },
 
     async downloadKWICTableExcel(selectedMetadata) {
-      const exportRows = await this.getExportRows();
+      this.errorMessage = "";
 
-      if (exportRows.length > 0) {
+      try {
+        const exportRows = await this.getExportRows();
+
+        if (exportRows.length === 0) {
+          this.errorMessage =
+            i18n.downloadFeedback?.error || "Kunde inte starta nedladdningen.";
+          return false;
+        }
+
         const data = exportRows.map((obj) => {
           let newObj = {};
           Object.keys(this.columnNames).forEach((key) => {
@@ -399,16 +407,33 @@ export const kwicDataStore = defineStore("kwicData", {
         zip.file("kwicData.xlsx", buffer);
         zip.file("metadata.txt", selectedMetadata);
 
-        zip.generateAsync({ type: "blob" }).then((content) => {
-          downloadDataStore().setupDownload("kwicExcel.zip", content);
-        });
+        const content = await zip.generateAsync({ type: "blob" });
+        downloadDataStore().setupDownload("kwicExcel.zip", content);
+        return true;
+      } catch (error) {
+        if (error.response?.status === 404) {
+          this.errorMessage = i18n.accessibility.ticketExpired;
+          this.resetTicketState();
+        } else {
+          this.errorMessage = this.getErrorMessage(error);
+        }
+        console.error("Error downloading KWIC Excel:", error);
+        return false;
       }
     },
 
     async downloadKWICTableCSV(selectedMetadata) {
-      const exportRows = await this.getExportRows();
+      this.errorMessage = "";
 
-      if (exportRows.length > 0) {
+      try {
+        const exportRows = await this.getExportRows();
+
+        if (exportRows.length === 0) {
+          this.errorMessage =
+            i18n.downloadFeedback?.error || "Kunde inte starta nedladdningen.";
+          return false;
+        }
+
         const headerRow = Object.values(this.columnNames).join(",");
 
         const dataRows = exportRows
@@ -427,9 +452,18 @@ export const kwicDataStore = defineStore("kwicData", {
         zip.file("kwicData.csv", csvContent);
         zip.file("metadata.txt", selectedMetadata);
 
-        zip.generateAsync({ type: "blob" }).then((content) => {
-          downloadDataStore().setupDownload("kwicCSV.zip", content);
-        });
+        const content = await zip.generateAsync({ type: "blob" });
+        downloadDataStore().setupDownload("kwicCSV.zip", content);
+        return true;
+      } catch (error) {
+        if (error.response?.status === 404) {
+          this.errorMessage = i18n.accessibility.ticketExpired;
+          this.resetTicketState();
+        } else {
+          this.errorMessage = this.getErrorMessage(error);
+        }
+        console.error("Error downloading KWIC CSV:", error);
+        return false;
       }
     },
   },

--- a/src/stores/wordTrendsDataStore.js
+++ b/src/stores/wordTrendsDataStore.js
@@ -254,22 +254,39 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
     },
 
     async downloadSpeechesCSV() {
-      if (!this.ticketId) return;
-      const response = await api.get(
-        `/tools/word_trend_speeches/download/${this.ticketId}`,
-        { params: { format: "csv" }, responseType: "blob" },
-      );
-      downloadDataStore().setupDownload(
-        downloadDataStore().getFilenameFromDisposition(
-          response.headers,
-          `word_trend_speeches_${this.ticketId}.zip`,
-        ),
-        response.data,
-      );
+      if (!this.ticketId) return false;
+      this.speechesErrorMessage = "";
+
+      try {
+        const response = await api.get(
+          `/tools/word_trend_speeches/download/${this.ticketId}`,
+          { params: { format: "csv" }, responseType: "blob" },
+        );
+        downloadDataStore().setupDownload(
+          downloadDataStore().getFilenameFromDisposition(
+            response.headers,
+            `word_trend_speeches_${this.ticketId}.zip`,
+          ),
+          response.data,
+        );
+        return true;
+      } catch (error) {
+        if (error.response?.status === 404) {
+          this.speechesErrorMessage = i18n.accessibility.ticketExpired;
+          this.resetSpeechesTicketState();
+        } else {
+          this.speechesErrorMessage =
+            error?.response?.data?.detail ||
+            error?.message ||
+            "Kunde inte hämta anföranden.";
+        }
+        console.error("Error downloading word trend speeches CSV:", error);
+        return false;
+      }
     },
 
     async downloadSpeechesExcel() {
-      if (!this.ticketId) return;
+      if (!this.ticketId) return false;
       this.speechesErrorMessage = "";
 
       try {
@@ -280,7 +297,11 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
         const speechList = await downloadDataStore().extractJsonPayloadFromZip(
           response.data,
         );
-        if (speechList.length === 0) return;
+        if (speechList.length === 0) {
+          this.speechesErrorMessage =
+            i18n.downloadFeedback?.error || "Kunde inte starta nedladdningen.";
+          return false;
+        }
         const headers = [
           "year",
           "name",
@@ -302,9 +323,9 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
         const buffer = await workbook.xlsx.writeBuffer();
         const zip = new JSZip();
         zip.file("word_trend_speeches.xlsx", buffer);
-        zip.generateAsync({ type: "blob" }).then((content) => {
-          downloadDataStore().setupDownload("word_trend_speeches.zip", content);
-        });
+        const content = await zip.generateAsync({ type: "blob" });
+        downloadDataStore().setupDownload("word_trend_speeches.zip", content);
+        return true;
       } catch (error) {
         if (error.response?.status === 404) {
           this.speechesErrorMessage = i18n.accessibility.ticketExpired;
@@ -316,6 +337,7 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
             "Kunde inte hämta anföranden.";
         }
         console.error("Error downloading word trend speeches Excel:", error);
+        return false;
       }
     },
 


### PR DESCRIPTION
Fixes #178

## Summary

This adds non-blocking feedback for delayed download actions in the frontend. Users now get immediate feedback when a download is being prepared, repeated clicks on the same active action are prevented, and the surrounding table remains interactive while the download starts.

## What Changed

- Added shared tracked download state and notification helpers for delayed downloads
- Added per-action loading feedback to the in-scope download menus
- Disabled only the active download item while that action is running
- Added start, success, and failure notifications for delayed downloads
- Updated the relevant download flows to return explicit success/failure so the UI can react consistently
- Added i18n strings for download feedback messages

## Scope

Included:
- Word trends speech downloads
- KWIC CSV, Excel, and speech downloads
- Speeches archive downloads

## Notes

The visible feedback is primarily the notification shown immediately after click. The active menu item also shows loading state and is disabled while running, but that is most noticeable if the dropdown is reopened during a long-running preparation step.