### PR TITLE
fix(download): replace Notify import with useQuasar() in store action

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -116,7 +116,7 @@ export default configure(function (ctx) {
       // directives: [],
 
       // Quasar plugins
-      plugins: [],
+      plugins: ["Notify"],
     },
 
     // animations: 'all', // --- includes all animations

--- a/src/stores/downloadDataStore.js
+++ b/src/stores/downloadDataStore.js
@@ -1,7 +1,7 @@
 import { defineStore } from "pinia";
 import { api } from "boot/axios";
+import { useQuasar } from "quasar";
 import JSZip from "jszip";
-import { Notify } from "quasar";
 import i18n from "src/i18n/sv/index.js";
 import { metaDataStore } from "./metaDataStore";
 
@@ -52,6 +52,7 @@ export const downloadDataStore = defineStore("downloadData", {
         return false;
       }
 
+      const $q = useQuasar();
       const messages = this.getDownloadFeedbackMessages();
       const preparingMessage = options.preparingMessage || messages.preparing;
       const successMessage = options.successMessage || messages.success;
@@ -71,7 +72,7 @@ export const downloadDataStore = defineStore("downloadData", {
       this.setDownloadActive(downloadKey, true);
 
       try {
-        dismissPreparingNotify = Notify.create({
+        dismissPreparingNotify = $q.notify({
           spinner: true,
           message: preparingMessage,
           timeout: 0,
@@ -89,7 +90,7 @@ export const downloadDataStore = defineStore("downloadData", {
       }
 
       if (taskError) {
-        Notify.create({
+        $q.notify({
           type: "negative",
           message: this.getDownloadErrorMessage(
             taskError,
@@ -102,7 +103,7 @@ export const downloadDataStore = defineStore("downloadData", {
       }
 
       if (!wasSuccessful) {
-        Notify.create({
+        $q.notify({
           type: "negative",
           message: resolveErrorMessage(),
           timeout: 3000,
@@ -111,7 +112,7 @@ export const downloadDataStore = defineStore("downloadData", {
         return false;
       }
 
-      Notify.create({
+      $q.notify({
         type: "positive",
         message: successMessage,
         timeout: 1500,

--- a/src/stores/downloadDataStore.js
+++ b/src/stores/downloadDataStore.js
@@ -69,14 +69,14 @@ export const downloadDataStore = defineStore("downloadData", {
       let wasSuccessful = false;
 
       this.setDownloadActive(downloadKey, true);
-      dismissPreparingNotify = Notify.create({
-        spinner: true,
-        message: preparingMessage,
-        timeout: 0,
-        position: "top",
-      });
 
       try {
+        dismissPreparingNotify = Notify.create({
+          spinner: true,
+          message: preparingMessage,
+          timeout: 0,
+          position: "top",
+        });
         const result = await task();
         wasSuccessful = result !== false;
       } catch (error) {


### PR DESCRIPTION
Module-level Notify imported from 'quasar' is not initialized at the time a Pinia store action runs in a tree-shaken build, causing 'Notify.create is not a function'. The correct Quasar v2 pattern is to call useQuasar() inside the action to get the live instance.