### PR TITLE
feat(word-trends): add ZIP speech archive download to word trends speeches table

### DIFF
--- a/src/components/wordTrendsSpeechTable.vue
+++ b/src/components/wordTrendsSpeechTable.vue
@@ -15,22 +15,63 @@
           <b>{{ wtStore.speechesTotalHits }}</b>
           {{ $t("searchResult2") }}
         </q-item-label>
-        <q-btn-dropdown no-caps icon="download" class="text-grey-8 col-3" color="secondary"
-          :label="$t('downloadSpeech')" style="width: fit-content">
+        <q-btn-dropdown
+          no-caps
+          icon="download"
+          class="text-grey-8 col-3"
+          color="secondary"
+          :label="$t('downloadSpeech')"
+          style="width: fit-content"
+        >
           <q-list>
-            <q-item clickable v-close-popup :disable="isDownloadActive(downloadKeys.csv)" @click="downloadCSV">
+            <q-item
+              clickable
+              v-close-popup
+              :disable="isDownloadActive(downloadKeys.csv)"
+              @click="downloadCSV"
+            >
               <q-item-section>
                 <q-item-label class="row items-center no-wrap">
-                  <q-spinner-tail v-if="isDownloadActive(downloadKeys.csv)" size="16px" class="q-mr-sm" />
+                  <q-spinner-tail
+                    v-if="isDownloadActive(downloadKeys.csv)"
+                    size="16px"
+                    class="q-mr-sm"
+                  />
                   {{ $t("downloadCSV") }}
                 </q-item-label>
               </q-item-section>
             </q-item>
-            <q-item clickable v-close-popup :disable="isDownloadActive(downloadKeys.excel)" @click="downloadExcel">
+            <q-item
+              clickable
+              v-close-popup
+              :disable="isDownloadActive(downloadKeys.excel)"
+              @click="downloadExcel"
+            >
               <q-item-section>
                 <q-item-label class="row items-center no-wrap">
-                  <q-spinner-tail v-if="isDownloadActive(downloadKeys.excel)" size="16px" class="q-mr-sm" />
+                  <q-spinner-tail
+                    v-if="isDownloadActive(downloadKeys.excel)"
+                    size="16px"
+                    class="q-mr-sm"
+                  />
                   {{ $t("downloadExcel") }}
+                </q-item-label>
+              </q-item-section>
+            </q-item>
+            <q-item
+              clickable
+              v-close-popup
+              :disable="isDownloadActive(downloadKeys.zip)"
+              @click="downloadZip"
+            >
+              <q-item-section>
+                <q-item-label class="row items-center no-wrap">
+                  <q-spinner-tail
+                    v-if="isDownloadActive(downloadKeys.zip)"
+                    size="16px"
+                    class="q-mr-sm"
+                  />
+                  {{ $t("downloadSpeechTextArchive") }}
                 </q-item-label>
               </q-item-section>
             </q-item>
@@ -38,14 +79,29 @@
         </q-btn-dropdown>
       </div>
 
-      <q-table ref="SpeechTable" bordered flat :rows="rows" :columns="columns" row-key="id"
-        :rows-per-page-options="[10, 20, 50]" v-model:pagination="pagination"
-        :loading="wtStore.speechesIsLoading || wtStore.speechesIsPageLoading" class="bg-grey-2" @request="onRequest">
+      <q-table
+        ref="SpeechTable"
+        bordered
+        flat
+        :rows="rows"
+        :columns="columns"
+        row-key="id"
+        :rows-per-page-options="[10, 20, 50]"
+        v-model:pagination="pagination"
+        :loading="wtStore.speechesIsLoading || wtStore.speechesIsPageLoading"
+        class="bg-grey-2"
+        @request="onRequest"
+      >
         <template v-slot:header="props">
           <q-tr :props="props">
             <q-th v-for="col in props.cols" :key="col.name" :props="props">
               {{ col.label }}
-              <q-icon v-if="col.label === 'Anförande'" name="info_outline" color="accent" class="q-mb-md q-ml-xs">
+              <q-icon
+                v-if="col.label === 'Anförande'"
+                name="info_outline"
+                color="accent"
+                class="q-mb-md q-ml-xs"
+              >
                 <q-tooltip>
                   {{ $t("accessibility.tooltipSpeechID") }}
                 </q-tooltip>
@@ -55,10 +111,20 @@
         </template>
         <template v-slot:body="props">
           <q-tr :props="props" @click="expandRow(props)" class="cursor-pointer">
-            <q-td v-for="col in props.cols" :key="col.name" :props="props" class="bg-white"
-              :class="props.expand ? 'bg-grey-3' : ''">
-              <q-item-label v-if="col.name === 'party'" :class="col.value === '[-]' ? 'text-italic text-grey-6' : 'text-bold'
-                " :style="{ color: metaStore.getPartyAbbrevColor(col.value) }">
+            <q-td
+              v-for="col in props.cols"
+              :key="col.name"
+              :props="props"
+              class="bg-white"
+              :class="props.expand ? 'bg-grey-3' : ''"
+            >
+              <q-item-label
+                v-if="col.name === 'party'"
+                :class="
+                  col.value === '[-]' ? 'text-italic text-grey-6' : 'text-bold'
+                "
+                :style="{ color: metaStore.getPartyAbbrevColor(col.value) }"
+              >
                 {{
                   col.value === "[-]"
                     ? $t("accessibility.metadataMissing")
@@ -68,19 +134,37 @@
                   {{ props.row.party_full }}
                 </q-tooltip>
               </q-item-label>
-              <q-item-label v-else-if="col.name === 'node_word'" class="text-bold">
+              <q-item-label
+                v-else-if="col.name === 'node_word'"
+                class="text-bold"
+              >
                 {{ col.value }}
               </q-item-label>
-              <q-item-label v-else-if="col.value === 'Okänd' || col.value === 'Okänt'" class="text-italic text-grey-6">
+              <q-item-label
+                v-else-if="col.value === 'Okänd' || col.value === 'Okänt'"
+                class="text-italic text-grey-6"
+              >
                 {{ $t("accessibility.metadataMissing") }}
               </q-item-label>
               <q-item-label v-else>
                 {{ col.value }}
               </q-item-label>
             </q-td>
-            <q-td auto-width class="bg-white" :class="props.expand ? 'bg-grey-3' : ''">
-              <q-btn size="sm" color="accent" round dense flat :icon="props.expand ? 'keyboard_arrow_up' : 'keyboard_arrow_down'
-                " />
+            <q-td
+              auto-width
+              class="bg-white"
+              :class="props.expand ? 'bg-grey-3' : ''"
+            >
+              <q-btn
+                size="sm"
+                color="accent"
+                round
+                dense
+                flat
+                :icon="
+                  props.expand ? 'keyboard_arrow_up' : 'keyboard_arrow_down'
+                "
+              />
             </q-td>
           </q-tr>
           <expandingTableRow :props="props" />
@@ -109,6 +193,7 @@ const wtStore = wordTrendsDataStore();
 const downloadKeys = {
   csv: "word-trends-speeches-csv",
   excel: "word-trends-speeches-excel",
+  zip: "word-trends-speeches-zip",
 };
 
 const SpeechTable = ref(null);
@@ -148,17 +233,33 @@ const isDownloadActive = (downloadKey) =>
   downloadStore.isDownloadActive(downloadKey);
 
 const downloadCSV = async () => {
-  await downloadStore.runTrackedDownload(downloadKeys.csv, () =>
-    wtStore.downloadSpeechesCSV(), {
-    getErrorMessage: () => wtStore.speechesErrorMessage,
-  });
+  await downloadStore.runTrackedDownload(
+    downloadKeys.csv,
+    () => wtStore.downloadSpeechesCSV(),
+    {
+      getErrorMessage: () => wtStore.speechesErrorMessage,
+    },
+  );
 };
 
 const downloadExcel = async () => {
-  await downloadStore.runTrackedDownload(downloadKeys.excel, () =>
-    wtStore.downloadSpeechesExcel(), {
-    getErrorMessage: () => wtStore.speechesErrorMessage,
-  });
+  await downloadStore.runTrackedDownload(
+    downloadKeys.excel,
+    () => wtStore.downloadSpeechesExcel(),
+    {
+      getErrorMessage: () => wtStore.speechesErrorMessage,
+    },
+  );
+};
+
+const downloadZip = async () => {
+  await downloadStore.runTrackedDownload(
+    downloadKeys.zip,
+    () => wtStore.downloadSpeechesZip(),
+    {
+      getErrorMessage: () => wtStore.speechesErrorMessage,
+    },
+  );
 };
 
 const rows = computed(() =>

--- a/src/i18n/en-US/index.js
+++ b/src/i18n/en-US/index.js
@@ -8,6 +8,7 @@ export default {
   downloadSpeechCsvArchive: "Download CSV archive (.zip)",
   downloadSpeechJsonArchive: "Download JSON archive (.zip)",
   downloadSpeechTextArchive: "Download speeches (.zip)",
+  downloadSpeech: "Download speeches",
   downloadFeedback: {
     preparing: "Preparing download...",
     success: "The download has started.",

--- a/src/i18n/en-US/index.js
+++ b/src/i18n/en-US/index.js
@@ -7,6 +7,7 @@ export default {
   kwicFetchError: "Could not load KWIC results.",
   downloadSpeechCsvArchive: "Download CSV archive (.zip)",
   downloadSpeechJsonArchive: "Download JSON archive (.zip)",
+  downloadSpeechTextArchive: "Download speeches (.zip)",
   downloadFeedback: {
     preparing: "Preparing download...",
     success: "The download has started.",

--- a/src/i18n/sv/index.js
+++ b/src/i18n/sv/index.js
@@ -185,7 +185,6 @@ export default {
   downloadSpeechJsonArchive: "Ladda ner JSON-arkiv (.zip)",
   downloadExcel: "Ladda ner Excel",
   downloadSpeechTextArchive: "Ladda ner tal (.zip)",
-  downloadSpeech: "Tal",
   downloadFeedback: {
     preparing: "Förbereder nedladdning...",
     success: "Nedladdningen har startat.",

--- a/src/i18n/sv/index.js
+++ b/src/i18n/sv/index.js
@@ -9,7 +9,7 @@ export default {
     humlab: "https://umu.se/humlab",
     huminfra: "https://www.huminfra.se/",
     swedebGithub: "https://github.com/humlab-swedeb",
-    dhnb: "https://journals.uio.no/dhnbpub/article/view/13135"
+    dhnb: "https://journals.uio.no/dhnbpub/article/view/13135",
   },
 
   dataVersion: "Data-version:",
@@ -184,6 +184,7 @@ export default {
   downloadSpeechCsvArchive: "Ladda ner CSV-arkiv (.zip)",
   downloadSpeechJsonArchive: "Ladda ner JSON-arkiv (.zip)",
   downloadExcel: "Ladda ner Excel",
+  downloadSpeechTextArchive: "Ladda ner tal (.zip)",
   downloadSpeech: "Tal",
   downloadFeedback: {
     preparing: "Förbereder nedladdning...",
@@ -211,13 +212,15 @@ export default {
   avgränsa anförandena till bland annat vissa partier, talare eller år. Observera att sökningar som har en hög träffrekvens kan ta längre tid.`,
 
   // PDF PAGE ------------------------------------------------
-  pageNrInfoText: "OBS, det kan vara nödvändigt att bläddra ett par sidor för att komma till rätt anförande",
+  pageNrInfoText:
+    "OBS, det kan vara nödvändigt att bläddra ett par sidor för att komma till rätt anförande",
   nextPage: "Nästa sida",
   previousPage: "Föregående sida",
   zoomIn: "Zooma in",
   zoomOut: "Zooma ut",
   closeSpeech: "Stäng anförande",
-  riksdagenLinkText: "För mer information om riksdagsprotokollet och andra relaterade dokument, se",
+  riksdagenLinkText:
+    "För mer information om riksdagsprotokollet och andra relaterade dokument, se",
   riksdagenLink: "https://www.riksdagen.se",
 
   // ABOUT PAGE ------------------------------------------------
@@ -613,7 +616,6 @@ export default {
     10: {
       q: "Var är det en pik/dipp runt 1975 när jag söker i ordtrenderverktyget?",
 
-
       a: `Riksdagen ändrade från hela kalenderår till riksdagsår (cirka september till juni) 1975/1976.
 
       Det påverkade även vilka år som angavs i riksdagsprotokollens namn (t ex från 1972 till 1978/79).
@@ -638,8 +640,7 @@ export default {
       "SWERIK-records: https://github.com/swerik-project/riksdagen-records",
     swerik_persons:
       "SWERIK-persons: https://github.com/swerik-project/riksdagen-persons",
-    swedeb_ref:
-      "Nedladdat från: https://riksdagsdebatter.se/",
+    swedeb_ref: "Nedladdat från: https://riksdagsdebatter.se/",
   },
 
   //ACCessibility ------------------------------------------------

--- a/src/stores/wordTrendsDataStore.js
+++ b/src/stores/wordTrendsDataStore.js
@@ -341,6 +341,38 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
       }
     },
 
+    async downloadSpeechesZip() {
+      if (!this.ticketId) return false;
+      this.speechesErrorMessage = "";
+
+      try {
+        const response = await api.get(
+          `/tools/word_trend_speeches/archive/${encodeURIComponent(this.ticketId)}`,
+          { responseType: "blob" },
+        );
+        downloadDataStore().setupDownload(
+          downloadDataStore().getFilenameFromDisposition(
+            response.headers,
+            `word_trend_speeches_archive_${this.ticketId}.zip`,
+          ),
+          response.data,
+        );
+        return true;
+      } catch (error) {
+        if (error.response?.status === 404) {
+          this.speechesErrorMessage = i18n.accessibility.ticketExpired;
+          this.resetSpeechesTicketState();
+        } else {
+          this.speechesErrorMessage =
+            error?.response?.data?.detail ||
+            error?.message ||
+            "Kunde inte hämta anföranden.";
+        }
+        console.error("Error downloading word trend speeches ZIP:", error);
+        return false;
+      }
+    },
+
     async getWordHits(search) {
       const terms = search.split(",");
 


### PR DESCRIPTION
## Summary

Adds a ZIP speech archive download option to the Word Trends speeches table, wiring up the new `GET /tools/word_trend_speeches/archive/{ticket_id}` backend endpoint.

### Changes

- **`wordTrendsDataStore.js`**: New `downloadSpeechesZip()` action — calls the archive endpoint with `responseType: blob`, then passes the file through `downloadDataStore.setupDownload()` with filename derived from the `Content-Disposition` header. Handles 404 (expired ticket) by resetting ticket state and showing a translated error message.

- **`wordTrendsSpeechTable.vue`**: Replaces the single download button with a `q-btn-dropdown` offering three options — CSV, Excel, and ZIP. Each option shows a spinner while its own download is in progress and is disabled during that time.

- **`i18n/sv/index.js`** and **`i18n/en-US/index.js`**: New translation key for the ZIP download label.

## Backend dependency

Requires the backend `GET /tools/word_trend_speeches/archive/{ticket_id}` endpoint to be deployed (available in the corresponding backend staging PR).