### PR TITLE
feat(stores): wire archive downloads to ticket-based POST→poll→GET flow

### DIFF
--- a/src/i18n/en-US/index.js
+++ b/src/i18n/en-US/index.js
@@ -13,6 +13,8 @@ export default {
     preparing: "Preparing download...",
     success: "The download has started.",
     error: "Could not start the download.",
+    archiveGenerationFailed: "Archive generation failed.",
+    archiveGenerationTimeout: "Archive generation timed out.",
   },
   accessibility: {
     loadingResults: "Loading results, please wait...",

--- a/src/i18n/sv/index.js
+++ b/src/i18n/sv/index.js
@@ -189,6 +189,8 @@ export default {
     preparing: "Förbereder nedladdning...",
     success: "Nedladdningen har startat.",
     error: "Kunde inte starta nedladdningen.",
+    archiveGenerationFailed: "Arkivgenerering misslyckades.",
+    archiveGenerationTimeout: "Tidsgränsen för arkivgenerering uppnåddes.",
   },
 
   kwicLable: {

--- a/src/stores/__tests__/ticketPolling.spec.js
+++ b/src/stores/__tests__/ticketPolling.spec.js
@@ -1,10 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   getTicketPollDelayMs,
+  pollArchiveTicket,
   TICKET_POLL_INTERVAL_MS,
   TICKET_POLL_MAX_ATTEMPTS,
 } from "../ticketPolling";
+import i18n from "src/i18n/sv/index.js";
 
 describe("getTicketPollDelayMs", () => {
   it("uses Retry-After when the header is a positive integer", () => {
@@ -27,5 +29,173 @@ describe("getTicketPollDelayMs", () => {
 
   it("allows 180 seconds of polling when Retry-After is 2 seconds", () => {
     expect(TICKET_POLL_MAX_ATTEMPTS * 2).toBe(180);
+  });
+});
+
+describe("pollArchiveTicket", () => {
+  let api;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    api = { get: vi.fn() };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("success path", () => {
+    it("resolves immediately when the first poll returns ready", async () => {
+      const data = { status: "ready", download_url: "/files/archive.zip" };
+      api.get.mockResolvedValue({ data, headers: {} });
+
+      const result = await pollArchiveTicket(api, {
+        statusUrl: "/v1/tools/archive/abc/status",
+        maxAttempts: 3,
+      });
+
+      expect(api.get).toHaveBeenCalledOnce();
+      expect(api.get).toHaveBeenCalledWith("/v1/tools/archive/abc/status");
+      expect(result).toEqual(data);
+    });
+
+    it("resolves after a pending response followed by ready", async () => {
+      api.get
+        .mockResolvedValueOnce({ data: { status: "pending" }, headers: {} })
+        .mockResolvedValueOnce({
+          data: { status: "ready", download_url: "/files/archive.zip" },
+          headers: {},
+        });
+
+      const promise = pollArchiveTicket(api, {
+        statusUrl: "/v1/tools/archive/abc/status",
+        maxAttempts: 5,
+      });
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      expect(api.get).toHaveBeenCalledTimes(2);
+      expect(result.status).toBe("ready");
+    });
+  });
+
+  describe("error path", () => {
+    it("throws with the server error message when status is error", async () => {
+      api.get.mockResolvedValue({
+        data: { status: "error", error: "Disk full" },
+        headers: {},
+      });
+
+      await expect(
+        pollArchiveTicket(api, { statusUrl: "/v1/tools/archive/abc/status" }),
+      ).rejects.toThrow("Disk full");
+    });
+
+    it("falls back to the i18n message when error status has no message", async () => {
+      api.get.mockResolvedValue({ data: { status: "error" }, headers: {} });
+
+      await expect(
+        pollArchiveTicket(api, { statusUrl: "/v1/tools/archive/abc/status" }),
+      ).rejects.toThrow(i18n.downloadFeedback.archiveGenerationFailed);
+    });
+  });
+
+  describe("max-attempts timeout", () => {
+    it("throws the i18n timeout message after exhausting max attempts", async () => {
+      api.get.mockResolvedValue({ data: { status: "pending" }, headers: {} });
+
+      const promise = pollArchiveTicket(api, {
+        statusUrl: "/v1/tools/archive/abc/status",
+        maxAttempts: 2,
+      });
+      // Attach the rejection handler before advancing timers so the rejection
+      // is handled the moment it occurs and does not become an unhandled rejection.
+      const assertion = expect(promise).rejects.toThrow(
+        i18n.downloadFeedback.archiveGenerationTimeout,
+      );
+      await vi.runAllTimersAsync();
+      await assertion;
+      expect(api.get).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("onStatus callback", () => {
+    it("calls onStatus with each polled status string in order", async () => {
+      const onStatus = vi.fn();
+      api.get
+        .mockResolvedValueOnce({ data: { status: "pending" }, headers: {} })
+        .mockResolvedValueOnce({ data: { status: "ready" }, headers: {} });
+
+      const promise = pollArchiveTicket(api, {
+        statusUrl: "/v1/tools/archive/abc/status",
+        maxAttempts: 5,
+        onStatus,
+      });
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(onStatus).toHaveBeenCalledTimes(2);
+      expect(onStatus).toHaveBeenNthCalledWith(1, "pending");
+      expect(onStatus).toHaveBeenNthCalledWith(2, "ready");
+    });
+  });
+
+  describe("Retry-After backoff", () => {
+    it("waits the Retry-After header duration before the next poll", async () => {
+      api.get
+        .mockResolvedValueOnce({
+          data: { status: "pending" },
+          headers: { "retry-after": "5" },
+        })
+        .mockResolvedValueOnce({ data: { status: "ready" }, headers: {} });
+
+      const promise = pollArchiveTicket(api, {
+        statusUrl: "/v1/tools/archive/abc/status",
+        maxAttempts: 3,
+      });
+
+      // First api.get is initiated synchronously when the async function starts.
+      expect(api.get).toHaveBeenCalledTimes(1);
+
+      // Drain the first awaited resolution so the 5 s setTimeout is scheduled.
+      await vi.advanceTimersByTimeAsync(0);
+
+      // 4 999 ms elapsed — the 5 s Retry-After timer has not yet fired.
+      await vi.advanceTimersByTimeAsync(4999);
+      expect(api.get).toHaveBeenCalledTimes(1);
+
+      // 5 000 ms total — timer fires, second poll executes.
+      await vi.advanceTimersByTimeAsync(1);
+      const result = await promise;
+
+      expect(api.get).toHaveBeenCalledTimes(2);
+      expect(result.status).toBe("ready");
+    });
+
+    it("waits the default interval when Retry-After header is absent", async () => {
+      api.get
+        .mockResolvedValueOnce({ data: { status: "pending" }, headers: {} })
+        .mockResolvedValueOnce({ data: { status: "ready" }, headers: {} });
+
+      const promise = pollArchiveTicket(api, {
+        statusUrl: "/v1/tools/archive/abc/status",
+        maxAttempts: 3,
+      });
+
+      expect(api.get).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      // One millisecond short of the default interval — still waiting.
+      await vi.advanceTimersByTimeAsync(TICKET_POLL_INTERVAL_MS - 1);
+      expect(api.get).toHaveBeenCalledTimes(1);
+
+      // Default interval elapsed — second poll executes.
+      await vi.advanceTimersByTimeAsync(1);
+      const result = await promise;
+
+      expect(api.get).toHaveBeenCalledTimes(2);
+      expect(result.status).toBe("ready");
+    });
   });
 });

--- a/src/stores/downloadDataStore.js
+++ b/src/stores/downloadDataStore.js
@@ -4,15 +4,23 @@ import { Notify } from "quasar";
 import JSZip from "jszip";
 import i18n from "src/i18n/sv/index.js";
 import { metaDataStore } from "./metaDataStore";
+import { pollArchiveTicket } from "./ticketPolling";
 
 export const downloadDataStore = defineStore("downloadData", {
   state: () => ({
     activeDownloads: {},
+    archiveTicketId: null,
+    archiveTicketStatus: null,
   }),
 
   actions: {
     isDownloadActive(downloadKey) {
       return Boolean(this.activeDownloads[downloadKey]);
+    },
+
+    resetArchiveTicketState() {
+      this.archiveTicketId = null;
+      this.archiveTicketStatus = null;
     },
 
     setDownloadActive(downloadKey, isActive) {
@@ -255,26 +263,37 @@ export const downloadDataStore = defineStore("downloadData", {
     },
 
     async downloadSpeechesZipByTicket(ticketId) {
-      try {
-        const response = await api.get(
-          `/tools/speeches/archive/${encodeURIComponent(ticketId)}`,
-          {
-            responseType: "blob",
-          },
-        );
+      this.resetArchiveTicketState();
 
-        this.setupDownload(
-          this.getFilenameFromDisposition(
-            response.headers,
-            `speeches_${ticketId}.zip`,
-          ),
-          response.data,
-        );
-        return true;
-      } catch (error) {
-        console.error("Error fetching ticket download:", error);
-        throw error;
-      }
+      // 1. Request archive ticket
+      const prepareResponse = await api.post(
+        `/tools/speeches/archive/${encodeURIComponent(ticketId)}?archive_format=zip`,
+      );
+      const archiveTicketId = prepareResponse.data.archive_ticket_id;
+      this.archiveTicketId = archiveTicketId;
+      this.archiveTicketStatus = "pending";
+
+      // 2. Poll until ready
+      await pollArchiveTicket(api, {
+        statusUrl: `/tools/speeches/archive/status/${archiveTicketId}`,
+        onStatus: (status) => {
+          this.archiveTicketStatus = status;
+        },
+      });
+
+      // 3. Download the artifact
+      const downloadResponse = await api.get(
+        `/tools/speeches/archive/download/${archiveTicketId}`,
+        { responseType: "blob" },
+      );
+      this.setupDownload(
+        this.getFilenameFromDisposition(
+          downloadResponse.headers,
+          `speeches_${ticketId}.zip`,
+        ),
+        downloadResponse.data,
+      );
+      return true;
     },
   },
 });

--- a/src/stores/downloadDataStore.js
+++ b/src/stores/downloadDataStore.js
@@ -265,35 +265,41 @@ export const downloadDataStore = defineStore("downloadData", {
     async downloadSpeechesZipByTicket(ticketId) {
       this.resetArchiveTicketState();
 
-      // 1. Request archive ticket
-      const prepareResponse = await api.post(
-        `/tools/speeches/archive/${encodeURIComponent(ticketId)}?archive_format=zip`,
-      );
-      const archiveTicketId = prepareResponse.data.archive_ticket_id;
-      this.archiveTicketId = archiveTicketId;
-      this.archiveTicketStatus = "pending";
+      try {
+        // 1. Request archive ticket
+        const prepareResponse = await api.post(
+          `/tools/speeches/archive/${encodeURIComponent(ticketId)}?archive_format=zip`,
+        );
+        const archiveTicketId = prepareResponse.data.archive_ticket_id;
+        this.archiveTicketId = archiveTicketId;
+        this.archiveTicketStatus = "pending";
 
-      // 2. Poll until ready
-      await pollArchiveTicket(api, {
-        statusUrl: `/tools/speeches/archive/status/${archiveTicketId}`,
-        onStatus: (status) => {
-          this.archiveTicketStatus = status;
-        },
-      });
+        // 2. Poll until ready
+        await pollArchiveTicket(api, {
+          statusUrl: `/tools/speeches/archive/status/${archiveTicketId}`,
+          onStatus: (status) => {
+            this.archiveTicketStatus = status;
+          },
+        });
 
-      // 3. Download the artifact
-      const downloadResponse = await api.get(
-        `/tools/speeches/archive/download/${archiveTicketId}`,
-        { responseType: "blob" },
-      );
-      this.setupDownload(
-        this.getFilenameFromDisposition(
-          downloadResponse.headers,
-          `speeches_${ticketId}.zip`,
-        ),
-        downloadResponse.data,
-      );
-      return true;
+        // 3. Download the artifact
+        const downloadResponse = await api.get(
+          `/tools/speeches/archive/download/${archiveTicketId}`,
+          { responseType: "blob" },
+        );
+        this.setupDownload(
+          this.getFilenameFromDisposition(
+            downloadResponse.headers,
+            `speeches_${ticketId}.zip`,
+          ),
+          downloadResponse.data,
+        );
+        return true;
+      } catch (error) {
+        console.error("Error downloading speeches zip by ticket:", error);
+        this.resetArchiveTicketState();
+        return false;
+      }
     },
   },
 });

--- a/src/stores/ticketPolling.js
+++ b/src/stores/ticketPolling.js
@@ -1,3 +1,5 @@
+import i18n from "src/i18n/sv/index.js";
+
 export const TICKET_POLL_INTERVAL_MS = 2000;
 export const TICKET_POLL_MAX_ATTEMPTS = 90;
 
@@ -34,7 +36,7 @@ export async function pollArchiveTicket(
 
     if (status === "ready") return response.data;
     if (status === "error")
-      throw new Error(error || "Archive generation failed");
+      throw new Error(error || i18n.downloadFeedback?.archiveGenerationFailed);
 
     const delayMs = getTicketPollDelayMs(
       attempt,
@@ -42,5 +44,5 @@ export async function pollArchiveTicket(
     );
     await new Promise((resolve) => setTimeout(resolve, delayMs));
   }
-  throw new Error("Tidsgränsen för arkivgenerering uppnåddes.");
+  throw new Error(i18n.downloadFeedback?.archiveGenerationTimeout);
 }

--- a/src/stores/ticketPolling.js
+++ b/src/stores/ticketPolling.js
@@ -10,3 +10,37 @@ export function getTicketPollDelayMs(attempt, retryAfterHeader) {
 
   return TICKET_POLL_INTERVAL_MS;
 }
+
+/**
+ * Poll an archive-ticket status endpoint until the ticket is ready or fails.
+ *
+ * @param {import('axios').AxiosInstance} api - The axios instance to use.
+ * @param {object} options
+ * @param {string} options.statusUrl - URL of the archive status endpoint.
+ * @param {number} [options.maxAttempts] - Maximum poll attempts before timeout.
+ * @param {function} [options.onStatus] - Called with the status string on each poll.
+ * @returns {Promise<object>} Resolves with the final status response data when ready.
+ * @throws {Error} If the ticket enters an error state or the poll limit is reached.
+ */
+export async function pollArchiveTicket(
+  api,
+  { statusUrl, maxAttempts = TICKET_POLL_MAX_ATTEMPTS, onStatus } = {},
+) {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const response = await api.get(statusUrl);
+    const { status, error } = response.data;
+
+    if (onStatus) onStatus(status);
+
+    if (status === "ready") return response.data;
+    if (status === "error")
+      throw new Error(error || "Archive generation failed");
+
+    const delayMs = getTicketPollDelayMs(
+      attempt,
+      response.headers?.["retry-after"],
+    );
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+  throw new Error("Tidsgränsen för arkivgenerering uppnåddes.");
+}

--- a/src/stores/wordTrendsDataStore.js
+++ b/src/stores/wordTrendsDataStore.js
@@ -9,6 +9,7 @@ import i18n from "src/i18n/sv/index.js";
 import {
   getTicketPollDelayMs,
   TICKET_POLL_MAX_ATTEMPTS,
+  pollArchiveTicket,
 } from "./ticketPolling";
 
 const DEFAULT_PAGE_SIZE = 50;
@@ -35,6 +36,9 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
     // Ticket-based speeches state
     ticketId: null,
     ticketStatus: null,
+    // Archive ticket state
+    archiveTicketId: null,
+    archiveTicketStatus: null,
     speechesTotalHits: 0,
     speechesTotalPages: 0,
     speechesErrorMessage: "",
@@ -111,6 +115,11 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
         page: 1,
         rowsNumber: 0,
       };
+    },
+
+    resetArchiveTicketState() {
+      this.archiveTicketId = null;
+      this.archiveTicketStatus = null;
     },
 
     async waitForSpeechesTicketReady(requestId) {
@@ -344,18 +353,36 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
     async downloadSpeechesZip() {
       if (!this.ticketId) return false;
       this.speechesErrorMessage = "";
+      this.resetArchiveTicketState();
 
       try {
-        const response = await api.get(
-          `/tools/word_trend_speeches/archive/${encodeURIComponent(this.ticketId)}`,
+        // 1. Request archive ticket
+        const prepareResponse = await api.post(
+          `/tools/word_trend_speeches/archive/${encodeURIComponent(this.ticketId)}?archive_format=zip`,
+        );
+        const archiveTicketId = prepareResponse.data.archive_ticket_id;
+        this.archiveTicketId = archiveTicketId;
+        this.archiveTicketStatus = "pending";
+
+        // 2. Poll until ready
+        await pollArchiveTicket(api, {
+          statusUrl: `/tools/word_trend_speeches/archive/status/${archiveTicketId}`,
+          onStatus: (status) => {
+            this.archiveTicketStatus = status;
+          },
+        });
+
+        // 3. Download the artifact
+        const downloadResponse = await api.get(
+          `/tools/word_trend_speeches/archive/download/${archiveTicketId}`,
           { responseType: "blob" },
         );
         downloadDataStore().setupDownload(
           downloadDataStore().getFilenameFromDisposition(
-            response.headers,
+            downloadResponse.headers,
             `word_trend_speeches_archive_${this.ticketId}.zip`,
           ),
-          response.data,
+          downloadResponse.data,
         );
         return true;
       } catch (error) {


### PR DESCRIPTION
Replace legacy single-step GET streaming endpoints with the new ticket-based archive flow in all three download paths:

- ticketPolling.js: add pollArchiveTicket() helper that polls /archive/status/{id} using Retry-After back-off until ready or error
- wordTrendsDataStore: replace downloadSpeechesZip() with 3-step flow (POST create → poll status → GET blob) for word_trend_speeches group; add archiveTicketId/archiveTicketStatus state and resetArchiveTicketState()
- downloadDataStore: replace downloadSpeechesZipByTicket() with 3-step flow for speeches group; same state additions

No template changes needed — all call sites already wrap store methods in runTrackedDownload(downloadKeys.zip, ...) so isDownloadActive covers the full operation including archive polling.

Fixes: speechesTable.vue, kwicDataTable.vue, wordTrendsSpeechTable.vue downloads now use the new backend endpoints.