### PR TITLE
feat(downloads): add retrieval page, copy-link buttons, and i18n keys

### DIFF
--- a/src/components/speechesTable.vue
+++ b/src/components/speechesTable.vue
@@ -77,6 +77,23 @@
             </q-item>
           </q-list>
         </q-btn-dropdown>
+        <q-btn
+          v-if="
+            downloadStore.archiveRetrievalUrl &&
+            isDownloadActive(downloadKeys.zip)
+          "
+          flat
+          no-caps
+          dense
+          icon="link"
+          class="q-ml-sm text-grey-7"
+          :label="
+            linkCopied
+              ? $t('downloadRetrievalPage.linkCopied')
+              : $t('downloadRetrievalPage.copyLink')
+          "
+          @click="copyRetrievalLink"
+        />
       </div>
 
       <q-table
@@ -193,6 +210,20 @@ const downloadKeys = {
 };
 
 const SpeechTable = ref(null);
+const linkCopied = ref(false);
+
+const copyRetrievalLink = async () => {
+  if (!downloadStore.archiveRetrievalUrl) return;
+  try {
+    await navigator.clipboard.writeText(downloadStore.archiveRetrievalUrl);
+    linkCopied.value = true;
+    setTimeout(() => {
+      linkCopied.value = false;
+    }, 2000);
+  } catch {
+    // fallback: ignore clipboard errors silently
+  }
+};
 
 const pagination = computed({
   get: () => speechesStore.pagination,

--- a/src/components/speechesTable.vue
+++ b/src/components/speechesTable.vue
@@ -191,6 +191,7 @@
 <script setup>
 import { computed, ref } from "vue";
 import { api } from "boot/axios";
+import { useClipboardCopy } from "src/composables/useClipboardCopy.js";
 import i18n from "src/i18n/sv/index.js";
 import { metaDataStore } from "src/stores/metaDataStore.js";
 import { speechesDataStore } from "src/stores/speechesDataStore";
@@ -210,20 +211,9 @@ const downloadKeys = {
 };
 
 const SpeechTable = ref(null);
-const linkCopied = ref(false);
-
-const copyRetrievalLink = async () => {
-  if (!downloadStore.archiveRetrievalUrl) return;
-  try {
-    await navigator.clipboard.writeText(downloadStore.archiveRetrievalUrl);
-    linkCopied.value = true;
-    setTimeout(() => {
-      linkCopied.value = false;
-    }, 2000);
-  } catch {
-    // fallback: ignore clipboard errors silently
-  }
-};
+const { linkCopied, copyToClipboard } = useClipboardCopy();
+const copyRetrievalLink = () =>
+  copyToClipboard(downloadStore.archiveRetrievalUrl);
 
 const pagination = computed({
   get: () => speechesStore.pagination,

--- a/src/components/wordTrendsSpeechTable.vue
+++ b/src/components/wordTrendsSpeechTable.vue
@@ -77,6 +77,22 @@
             </q-item>
           </q-list>
         </q-btn-dropdown>
+        <q-btn
+          v-if="
+            wtStore.archiveRetrievalUrl && isDownloadActive(downloadKeys.zip)
+          "
+          flat
+          no-caps
+          dense
+          icon="link"
+          class="q-ml-sm text-grey-7"
+          :label="
+            linkCopied
+              ? $t('downloadRetrievalPage.linkCopied')
+              : $t('downloadRetrievalPage.copyLink')
+          "
+          @click="copyRetrievalLink"
+        />
       </div>
 
       <q-table
@@ -197,6 +213,20 @@ const downloadKeys = {
 };
 
 const SpeechTable = ref(null);
+const linkCopied = ref(false);
+
+const copyRetrievalLink = async () => {
+  if (!wtStore.archiveRetrievalUrl) return;
+  try {
+    await navigator.clipboard.writeText(wtStore.archiveRetrievalUrl);
+    linkCopied.value = true;
+    setTimeout(() => {
+      linkCopied.value = false;
+    }, 2000);
+  } catch {
+    // fallback: ignore clipboard errors silently
+  }
+};
 
 const pagination = computed({
   get: () => wtStore.speechesPagination,

--- a/src/components/wordTrendsSpeechTable.vue
+++ b/src/components/wordTrendsSpeechTable.vue
@@ -195,6 +195,7 @@
 
 <script setup>
 import { computed, ref } from "vue";
+import { useClipboardCopy } from "src/composables/useClipboardCopy.js";
 import { downloadDataStore } from "src/stores/downloadDataStore";
 import { metaDataStore } from "src/stores/metaDataStore.js";
 import { wordTrendsDataStore } from "src/stores/wordTrendsDataStore";
@@ -213,20 +214,8 @@ const downloadKeys = {
 };
 
 const SpeechTable = ref(null);
-const linkCopied = ref(false);
-
-const copyRetrievalLink = async () => {
-  if (!wtStore.archiveRetrievalUrl) return;
-  try {
-    await navigator.clipboard.writeText(wtStore.archiveRetrievalUrl);
-    linkCopied.value = true;
-    setTimeout(() => {
-      linkCopied.value = false;
-    }, 2000);
-  } catch {
-    // fallback: ignore clipboard errors silently
-  }
-};
+const { linkCopied, copyToClipboard } = useClipboardCopy();
+const copyRetrievalLink = () => copyToClipboard(wtStore.archiveRetrievalUrl);
 
 const pagination = computed({
   get: () => wtStore.speechesPagination,

--- a/src/composables/useClipboardCopy.js
+++ b/src/composables/useClipboardCopy.js
@@ -1,0 +1,31 @@
+import { ref, onUnmounted } from "vue";
+
+export function useClipboardCopy() {
+  const linkCopied = ref(false);
+  let resetTimer = null;
+
+  const copyToClipboard = async (text) => {
+    if (!text) return;
+    try {
+      await navigator.clipboard.writeText(text);
+      if (resetTimer !== null) {
+        clearTimeout(resetTimer);
+      }
+      linkCopied.value = true;
+      resetTimer = setTimeout(() => {
+        linkCopied.value = false;
+        resetTimer = null;
+      }, 2000);
+    } catch {
+      // fallback: ignore clipboard errors silently
+    }
+  };
+
+  onUnmounted(() => {
+    if (resetTimer !== null) {
+      clearTimeout(resetTimer);
+    }
+  });
+
+  return { linkCopied, copyToClipboard };
+}

--- a/src/i18n/en-US/index.js
+++ b/src/i18n/en-US/index.js
@@ -16,6 +16,22 @@ export default {
     archiveGenerationFailed: "Archive generation failed.",
     archiveGenerationTimeout: "Archive generation timed out.",
   },
+  downloadRetrievalPage: {
+    pending: "Preparing your archive…",
+    pendingHint:
+      "This page refreshes automatically. You can also bookmark this link and return later.",
+    readyTitle: "Your archive is ready",
+    readyDescription: "Click the button below to download your archive.",
+    expiresAt: "Available until:",
+    downloadButton: "Download archive",
+    failed: "Archive generation failed",
+    expiredTitle: "Link has expired",
+    expired:
+      "This archive link has expired or is no longer available. Please submit a new search to generate a new archive.",
+    backToSearch: "Back to search",
+    copyLink: "Copy retrieval link",
+    linkCopied: "Link copied!",
+  },
   accessibility: {
     loadingResults: "Loading results, please wait...",
     ticketExpired: "The results have expired. Please submit a new search.",

--- a/src/i18n/sv/index.js
+++ b/src/i18n/sv/index.js
@@ -192,6 +192,22 @@ export default {
     archiveGenerationFailed: "Arkivgenerering misslyckades.",
     archiveGenerationTimeout: "Tidsgränsen för arkivgenerering uppnåddes.",
   },
+  downloadRetrievalPage: {
+    pending: "Förbereder ditt arkiv…",
+    pendingHint:
+      "Sidan uppdateras automatiskt. Du kan bokmärka länken och återkomma senare.",
+    readyTitle: "Ditt arkiv är klart",
+    readyDescription: "Klicka på knappen nedan för att ladda ned ditt arkiv.",
+    expiresAt: "Tillgängligt till:",
+    downloadButton: "Ladda ned arkiv",
+    failed: "Arkivgenerering misslyckades",
+    expiredTitle: "Länken har gått ut",
+    expired:
+      "Den här arkivlänken har gått ut eller är inte längre tillgänglig. Gör en ny sökning för att generera ett nytt arkiv.",
+    backToSearch: "Tillbaka till sökning",
+    copyLink: "Kopiera hämtningslänk",
+    linkCopied: "Länk kopierad!",
+  },
 
   kwicLable: {
     left_word: "Vänster",

--- a/src/pages/DownloadRetrievalPage.vue
+++ b/src/pages/DownloadRetrievalPage.vue
@@ -92,7 +92,7 @@ import { api } from "boot/axios";
 const POLL_INTERVAL_MS = 5000;
 
 const route = useRoute();
-const archiveTicketId = route.params.archiveTicketId;
+const archiveTicketId = encodeURIComponent(route.params.archiveTicketId);
 
 const state = ref("pending"); // "pending" | "ready" | "failed" | "expired"
 const ticketStatus = ref(null);

--- a/src/pages/DownloadRetrievalPage.vue
+++ b/src/pages/DownloadRetrievalPage.vue
@@ -1,0 +1,187 @@
+<template>
+  <q-page class="q-px-md q-py-lg" style="max-width: 700px; margin: 0 auto">
+    <!-- PENDING state -->
+    <template v-if="state === 'pending'">
+      <div class="column items-center q-gutter-md q-py-xl">
+        <q-spinner-tail color="primary" size="64px" />
+        <q-item-label class="text-h6 text-center">
+          {{ $t("downloadRetrievalPage.pending") }}
+        </q-item-label>
+        <q-item-label caption class="text-center">
+          {{ $t("downloadRetrievalPage.pendingHint") }}
+        </q-item-label>
+      </div>
+    </template>
+
+    <!-- READY state -->
+    <template v-else-if="state === 'ready'">
+      <q-card flat bordered class="q-pa-lg">
+        <q-card-section>
+          <q-item-label class="text-h6 q-mb-sm">
+            {{ $t("downloadRetrievalPage.readyTitle") }}
+          </q-item-label>
+          <q-item-label class="q-mb-md">
+            {{ $t("downloadRetrievalPage.readyDescription") }}
+          </q-item-label>
+          <q-item-label v-if="ticketStatus?.expires_at" caption class="q-mb-lg">
+            {{ $t("downloadRetrievalPage.expiresAt") }}
+            {{ formattedExpiry }}
+          </q-item-label>
+        </q-card-section>
+        <q-card-actions vertical align="left">
+          <q-btn
+            color="primary"
+            icon="download"
+            no-caps
+            :label="$t('downloadRetrievalPage.downloadButton')"
+            :loading="isDownloading"
+            @click="triggerDownload"
+          />
+        </q-card-actions>
+      </q-card>
+    </template>
+
+    <!-- FAILED state -->
+    <template v-else-if="state === 'failed'">
+      <q-banner class="bg-negative text-white q-mb-md" rounded>
+        <template v-slot:avatar>
+          <q-icon name="error_outline" />
+        </template>
+        {{ $t("downloadRetrievalPage.failed") }}
+        <span v-if="errorDetail"> — {{ errorDetail }}</span>
+      </q-banner>
+      <q-btn
+        flat
+        no-caps
+        icon="arrow_back"
+        :to="'/'"
+        :label="$t('downloadRetrievalPage.backToSearch')"
+      />
+    </template>
+
+    <!-- EXPIRED / NOT FOUND state -->
+    <template v-else-if="state === 'expired'">
+      <q-card flat bordered class="q-pa-lg">
+        <q-card-section>
+          <q-item-label class="text-h6 q-mb-sm">
+            {{ $t("downloadRetrievalPage.expiredTitle") }}
+          </q-item-label>
+          <q-item-label>
+            {{ $t("downloadRetrievalPage.expired") }}
+          </q-item-label>
+        </q-card-section>
+        <q-card-actions>
+          <q-btn
+            flat
+            no-caps
+            icon="arrow_back"
+            :to="'/'"
+            :label="$t('downloadRetrievalPage.backToSearch')"
+          />
+        </q-card-actions>
+      </q-card>
+    </template>
+  </q-page>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, onUnmounted } from "vue";
+import { useRoute } from "vue-router";
+import { api } from "boot/axios";
+
+const POLL_INTERVAL_MS = 5000;
+
+const route = useRoute();
+const archiveTicketId = route.params.archiveTicketId;
+
+const state = ref("pending"); // "pending" | "ready" | "failed" | "expired"
+const ticketStatus = ref(null);
+const errorDetail = ref(null);
+const isDownloading = ref(false);
+
+let pollTimer = null;
+
+const formattedExpiry = computed(() => {
+  if (!ticketStatus.value?.expires_at) return "";
+  return new Date(ticketStatus.value.expires_at).toLocaleString();
+});
+
+async function fetchStatus() {
+  try {
+    const response = await api.get(`/downloads/${archiveTicketId}`);
+    ticketStatus.value = response.data;
+    const status = response.data.status;
+
+    if (status === "ready") {
+      state.value = "ready";
+      stopPolling();
+    } else if (status === "error") {
+      state.value = "failed";
+      errorDetail.value = response.data.error || null;
+      stopPolling();
+    } else {
+      // still pending — keep polling
+      state.value = "pending";
+    }
+  } catch (error) {
+    if (error.response?.status === 404) {
+      state.value = "expired";
+    } else {
+      state.value = "failed";
+      errorDetail.value =
+        error?.response?.data?.detail || error?.message || null;
+    }
+    stopPolling();
+  }
+}
+
+function startPolling() {
+  fetchStatus();
+  pollTimer = setInterval(fetchStatus, POLL_INTERVAL_MS);
+}
+
+function stopPolling() {
+  if (pollTimer !== null) {
+    clearInterval(pollTimer);
+    pollTimer = null;
+  }
+}
+
+async function triggerDownload() {
+  isDownloading.value = true;
+  try {
+    const response = await api.get(`/downloads/${archiveTicketId}/download`, {
+      responseType: "blob",
+    });
+    const disposition = response.headers["content-disposition"] || "";
+    const match = disposition.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/);
+    const filename = match
+      ? match[1].replace(/['"]/g, "")
+      : `archive_${archiveTicketId}.zip`;
+    const url = URL.createObjectURL(response.data);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    link.click();
+    URL.revokeObjectURL(url);
+  } catch (error) {
+    if (error.response?.status === 404 || error.response?.status === 410) {
+      state.value = "expired";
+    } else {
+      state.value = "failed";
+      errorDetail.value =
+        error?.response?.data?.detail || error?.message || null;
+    }
+  } finally {
+    isDownloading.value = false;
+  }
+}
+
+onMounted(() => {
+  startPolling();
+});
+
+onUnmounted(() => {
+  stopPolling();
+});
+</script>

--- a/src/pages/DownloadRetrievalPage.vue
+++ b/src/pages/DownloadRetrievalPage.vue
@@ -88,6 +88,7 @@
 import { ref, computed, onMounted, onUnmounted } from "vue";
 import { useRoute } from "vue-router";
 import { api } from "boot/axios";
+import { downloadDataStore } from "src/stores/downloadDataStore";
 
 const POLL_INTERVAL_MS = 5000;
 
@@ -162,17 +163,12 @@ async function triggerDownload() {
     const response = await api.get(`/downloads/${archiveTicketId}/download`, {
       responseType: "blob",
     });
-    const disposition = response.headers["content-disposition"] || "";
-    const match = disposition.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/);
-    const filename = match
-      ? match[1].replace(/['"]/g, "")
-      : `archive_${archiveTicketId}.zip`;
-    const url = URL.createObjectURL(response.data);
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = filename;
-    link.click();
-    URL.revokeObjectURL(url);
+    const store = downloadDataStore();
+    const filename = store.getFilenameFromDisposition(
+      response.headers,
+      `archive_${archiveTicketId}.zip`,
+    );
+    store.setupDownload(filename, response.data);
   } catch (error) {
     if (error.response?.status === 404 || error.response?.status === 410) {
       state.value = "expired";

--- a/src/pages/DownloadRetrievalPage.vue
+++ b/src/pages/DownloadRetrievalPage.vue
@@ -100,6 +100,7 @@ const errorDetail = ref(null);
 const isDownloading = ref(false);
 
 let pollTimer = null;
+let pollingActive = false;
 
 const formattedExpiry = computed(() => {
   if (!ticketStatus.value?.expires_at) return "";
@@ -135,14 +136,22 @@ async function fetchStatus() {
   }
 }
 
+async function schedulePoll() {
+  await fetchStatus();
+  if (pollingActive) {
+    pollTimer = setTimeout(schedulePoll, POLL_INTERVAL_MS);
+  }
+}
+
 function startPolling() {
-  fetchStatus();
-  pollTimer = setInterval(fetchStatus, POLL_INTERVAL_MS);
+  pollingActive = true;
+  schedulePoll();
 }
 
 function stopPolling() {
+  pollingActive = false;
   if (pollTimer !== null) {
-    clearInterval(pollTimer);
+    clearTimeout(pollTimer);
     pollTimer = null;
   }
 }

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -3,9 +3,11 @@ const routes = [
     path: "/",
     component: () => import("layouts/MainLayout.vue"),
     children: [
-
       { path: "pdf", component: () => import("pages/PdfPage.vue") },
-      { path: "pdf-pagewise", component: () => import("pages/PdfPageWise.vue") },
+      {
+        path: "pdf-pagewise",
+        component: () => import("pages/PdfPageWise.vue"),
+      },
 
       {
         path: "",
@@ -22,7 +24,11 @@ const routes = [
         component: () => import("pages/FAQPage.vue"),
         meta: { title: "FAQ" },
       },
-
+      {
+        path: "download/:archiveTicketId",
+        component: () => import("pages/DownloadRetrievalPage.vue"),
+        meta: { title: "Hämta arkiv" },
+      },
     ],
   },
   {

--- a/src/stores/downloadDataStore.js
+++ b/src/stores/downloadDataStore.js
@@ -11,6 +11,7 @@ export const downloadDataStore = defineStore("downloadData", {
     activeDownloads: {},
     archiveTicketId: null,
     archiveTicketStatus: null,
+    archiveRetrievalUrl: null,
   }),
 
   actions: {
@@ -21,6 +22,7 @@ export const downloadDataStore = defineStore("downloadData", {
     resetArchiveTicketState() {
       this.archiveTicketId = null;
       this.archiveTicketStatus = null;
+      this.archiveRetrievalUrl = null;
     },
 
     setDownloadActive(downloadKey, isActive) {
@@ -273,6 +275,7 @@ export const downloadDataStore = defineStore("downloadData", {
         const archiveTicketId = prepareResponse.data.archive_ticket_id;
         this.archiveTicketId = archiveTicketId;
         this.archiveTicketStatus = "pending";
+        this.archiveRetrievalUrl = prepareResponse.data.retrieval_url || null;
 
         // 2. Poll until ready
         await pollArchiveTicket(api, {

--- a/src/stores/wordTrendsDataStore.js
+++ b/src/stores/wordTrendsDataStore.js
@@ -39,6 +39,7 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
     // Archive ticket state
     archiveTicketId: null,
     archiveTicketStatus: null,
+    archiveRetrievalUrl: null,
     speechesTotalHits: 0,
     speechesTotalPages: 0,
     speechesErrorMessage: "",
@@ -120,6 +121,7 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
     resetArchiveTicketState() {
       this.archiveTicketId = null;
       this.archiveTicketStatus = null;
+      this.archiveRetrievalUrl = null;
     },
 
     async waitForSpeechesTicketReady(requestId) {
@@ -363,6 +365,7 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
         const archiveTicketId = prepareResponse.data.archive_ticket_id;
         this.archiveTicketId = archiveTicketId;
         this.archiveTicketStatus = "pending";
+        this.archiveRetrievalUrl = prepareResponse.data.retrieval_url || null;
 
         // 2. Poll until ready
         await pollArchiveTicket(api, {


### PR DESCRIPTION
- Add DownloadRetrievalPage.vue: polls GET /downloads/{id}, triggers download
- Add /download/:archiveTicketId route with meta title in routes.js
- Add archiveRetrievalUrl state to downloadDataStore and wordTrendsDataStore
- Add copyRetrievalLink() and copy-link button to speechesTable and wordTrendsSpeechTable
- Add downloadRetrievalPage i18n keys in sv and en-US