### PR TITLE
feat(kwic): replace client-side export with async archive

### DIFF
--- a/src/components/kwicDataTable.vue
+++ b/src/components/kwicDataTable.vue
@@ -266,10 +266,6 @@ const onRequest = async ({ pagination }) => {
   });
 };
 
-const getParamString = () => {
-  return metaStore.selectedMetadataToText("kwic");
-};
-
 const isDownloadActive = (downloadKey) =>
   downloadStore.isDownloadActive(downloadKey);
 

--- a/src/components/kwicDataTable.vue
+++ b/src/components/kwicDataTable.vue
@@ -71,6 +71,25 @@
           </q-item>
         </q-list>
       </q-btn-dropdown>
+
+      <q-btn
+        v-if="
+          kwicStore.archiveRetrievalUrl &&
+          (isDownloadActive(downloadKeys.excel) ||
+            isDownloadActive(downloadKeys.csv))
+        "
+        flat
+        no-caps
+        dense
+        icon="link"
+        class="q-ml-sm text-grey-7"
+        :label="
+          linkCopied
+            ? $t('downloadRetrievalPage.linkCopied')
+            : $t('downloadRetrievalPage.copyLink')
+        "
+        @click="copyRetrievalLink"
+      />
     </div>
     <q-table
       ref="KWICTable"
@@ -194,6 +213,7 @@ import { computed, ref } from "vue";
 import { metaDataStore } from "src/stores/metaDataStore";
 import { kwicDataStore } from "src/stores/kwicDataStore";
 import { downloadDataStore } from "src/stores/downloadDataStore";
+import { useClipboardCopy } from "src/composables/useClipboardCopy";
 import expandingTableRow from "src/components/expandingTableRow.vue";
 import loadingIcon from "src/components/loadingIcon.vue";
 import noResults from "src/components/noResults.vue";
@@ -201,6 +221,9 @@ import noResults from "src/components/noResults.vue";
 const metaStore = metaDataStore();
 const kwicStore = kwicDataStore();
 const downloadStore = downloadDataStore();
+const { linkCopied, copyToClipboard } = useClipboardCopy();
+
+const copyRetrievalLink = () => copyToClipboard(kwicStore.archiveRetrievalUrl);
 
 const downloadKeys = {
   csv: "kwic-csv",
@@ -253,7 +276,7 @@ const isDownloadActive = (downloadKey) =>
 const downloadKWICTableAsExcel = async () => {
   await downloadStore.runTrackedDownload(
     downloadKeys.excel,
-    () => kwicStore.downloadKWICTableExcel(getParamString()),
+    () => kwicStore.downloadKWICTableExcel(),
     {
       getErrorMessage: () => kwicStore.errorMessage,
     },
@@ -263,7 +286,7 @@ const downloadKWICTableAsExcel = async () => {
 const downloadKWICTableAsCSV = async () => {
   await downloadStore.runTrackedDownload(
     downloadKeys.csv,
-    () => kwicStore.downloadKWICTableCSV(getParamString()),
+    () => kwicStore.downloadKWICTableCSV(),
     {
       getErrorMessage: () => kwicStore.errorMessage,
     },

--- a/src/stores/kwicDataStore.js
+++ b/src/stores/kwicDataStore.js
@@ -330,50 +330,12 @@ export const kwicDataStore = defineStore("kwicData", {
       }
     },
 
-    async fetchKwicExportData() {
-      if (this.useTicketFlow && this.ticketId) {
-        const response = await api.get(
-          `/tools/kwic/download/${this.ticketId}`,
-          {
-            params: { format: "json" },
-            responseType: "blob",
-          },
-        );
-        return downloadDataStore().extractJsonPayloadFromZip(response.data);
-      }
-
-      const normalizedSearch = this.normalizeSearch(this.searchText);
-
-      if (!normalizedSearch) {
-        return [];
-      }
-
-      const path = this.getKwicResultsPath(normalizedSearch);
-      const additionalParams = {
-        words_before: this.wordsLeft,
-        words_after: this.wordsRight,
-        lemmatized: this.lemmatizeSearch,
-        ...(this.cutOff !== null && { cut_off: this.cutOff }),
-      };
-      const queryString = metaDataStore().getSelectedParamsAtSearch(
-        "kwic",
-        additionalParams,
-      );
-      const response = await api.get(`${path}?${queryString}`);
-
-      return response.data.kwic_list || [];
-    },
-
-    async getExportRows() {
-      if (this.useTicketFlow && this.ticketId) {
-        return this.fetchKwicExportData();
-      }
-
-      return this.kwicData || [];
-    },
-
     async downloadKwicArchive(format = "jsonl_gz") {
-      if (!this.ticketId) return false;
+      if (!this.ticketId) {
+        this.archiveRetrievalUrl = null;
+        this.errorMessage = i18n.accessibility.ticketExpired;
+        return false;
+      }
       this.errorMessage = "";
       this.archiveRetrievalUrl = null;
 
@@ -395,10 +357,12 @@ export const kwicDataStore = defineStore("kwicData", {
           `/downloads/${archiveTicketId}/download`,
           { responseType: "blob" },
         );
+        const archiveExtensions = { csv_gz: "csv.gz", jsonl_gz: "jsonl.gz" };
+        const fileExtension = archiveExtensions[format] ?? format;
         downloadDataStore().setupDownload(
           downloadDataStore().getFilenameFromDisposition(
             downloadResponse.headers,
-            `kwic_archive_${this.ticketId}.${format}`,
+            `kwic_archive_${this.ticketId}.${fileExtension}`,
           ),
           downloadResponse.data,
         );

--- a/src/stores/kwicDataStore.js
+++ b/src/stores/kwicDataStore.js
@@ -3,11 +3,10 @@ import { api } from "boot/axios";
 import axios from "axios";
 import { metaDataStore } from "./metaDataStore";
 import { downloadDataStore } from "./downloadDataStore";
-import JSZip from "jszip";
-import ExcelJS from "exceljs";
 import i18n from "src/i18n/sv/index.js";
 import {
   getTicketPollDelayMs,
+  pollArchiveTicket,
   TICKET_POLL_MAX_ATTEMPTS,
 } from "./ticketPolling";
 
@@ -52,6 +51,7 @@ export const kwicDataStore = defineStore("kwicData", {
     expiresAt: null,
     errorMessage: "",
     hasSubmittedQuery: false,
+    archiveRetrievalUrl: null,
     isLoading: false,
     isPageLoading: false,
     requestSequence: 0,
@@ -92,6 +92,7 @@ export const kwicDataStore = defineStore("kwicData", {
       this.totalHits = 0;
       this.totalPages = 0;
       this.expiresAt = null;
+      this.archiveRetrievalUrl = null;
       this.pagination = {
         ...this.pagination,
         page: 1,
@@ -371,44 +372,36 @@ export const kwicDataStore = defineStore("kwicData", {
       return this.kwicData || [];
     },
 
-    async downloadKWICTableExcel(selectedMetadata) {
+    async downloadKwicArchive(format = "jsonl_gz") {
+      if (!this.ticketId) return false;
       this.errorMessage = "";
+      this.archiveRetrievalUrl = null;
 
       try {
-        const exportRows = await this.getExportRows();
+        // 1. Request archive ticket
+        const prepareResponse = await api.post(
+          `/tools/kwic/archive/${encodeURIComponent(this.ticketId)}?archive_format=${encodeURIComponent(format)}`,
+        );
+        const archiveTicketId = prepareResponse.data.archive_ticket_id;
+        this.archiveRetrievalUrl = prepareResponse.data.retrieval_url || null;
 
-        if (exportRows.length === 0) {
-          this.errorMessage =
-            i18n.downloadFeedback?.error || "Kunde inte starta nedladdningen.";
-          return false;
-        }
-
-        const data = exportRows.map((obj) => {
-          let newObj = {};
-          Object.keys(this.columnNames).forEach((key) => {
-            newObj[this.columnNames[key]] = obj[key] ?? "";
-          });
-          return newObj;
+        // 2. Poll until ready via generic downloads endpoint
+        await pollArchiveTicket(api, {
+          statusUrl: `/downloads/${archiveTicketId}`,
         });
 
-        const workbook = new ExcelJS.Workbook();
-        const worksheet = workbook.addWorksheet("Sheet1");
-
-        worksheet.columns = Object.values(this.columnNames).map((header) => ({
-          header,
-          key: header,
-        }));
-
-        data.forEach((row) => worksheet.addRow(row));
-
-        const buffer = await workbook.xlsx.writeBuffer();
-
-        const zip = new JSZip();
-        zip.file("kwicData.xlsx", buffer);
-        zip.file("metadata.txt", selectedMetadata);
-
-        const content = await zip.generateAsync({ type: "blob" });
-        downloadDataStore().setupDownload("kwicExcel.zip", content);
+        // 3. Download the artifact
+        const downloadResponse = await api.get(
+          `/downloads/${archiveTicketId}/download`,
+          { responseType: "blob" },
+        );
+        downloadDataStore().setupDownload(
+          downloadDataStore().getFilenameFromDisposition(
+            downloadResponse.headers,
+            `kwic_archive_${this.ticketId}.${format}`,
+          ),
+          downloadResponse.data,
+        );
         return true;
       } catch (error) {
         if (error.response?.status === 404) {
@@ -417,54 +410,17 @@ export const kwicDataStore = defineStore("kwicData", {
         } else {
           this.errorMessage = this.getErrorMessage(error);
         }
-        console.error("Error downloading KWIC Excel:", error);
+        console.error("Error downloading KWIC archive:", error);
         return false;
       }
     },
 
-    async downloadKWICTableCSV(selectedMetadata) {
-      this.errorMessage = "";
+    async downloadKWICTableExcel() {
+      return this.downloadKwicArchive("xlsx");
+    },
 
-      try {
-        const exportRows = await this.getExportRows();
-
-        if (exportRows.length === 0) {
-          this.errorMessage =
-            i18n.downloadFeedback?.error || "Kunde inte starta nedladdningen.";
-          return false;
-        }
-
-        const headerRow = Object.values(this.columnNames).join(",");
-
-        const dataRows = exportRows
-          .map((obj) =>
-            Object.keys(this.columnNames)
-              .map(
-                (key) => `"${(obj[key] ?? "").toString().replace(/"/g, '""')}"`,
-              )
-              .join(","),
-          )
-          .join("\n");
-
-        const csvContent = headerRow + "\n" + dataRows;
-
-        const zip = new JSZip();
-        zip.file("kwicData.csv", csvContent);
-        zip.file("metadata.txt", selectedMetadata);
-
-        const content = await zip.generateAsync({ type: "blob" });
-        downloadDataStore().setupDownload("kwicCSV.zip", content);
-        return true;
-      } catch (error) {
-        if (error.response?.status === 404) {
-          this.errorMessage = i18n.accessibility.ticketExpired;
-          this.resetTicketState();
-        } else {
-          this.errorMessage = this.getErrorMessage(error);
-        }
-        console.error("Error downloading KWIC CSV:", error);
-        return false;
-      }
+    async downloadKWICTableCSV() {
+      return this.downloadKwicArchive("csv_gz");
     },
   },
 });


### PR DESCRIPTION
- add archiveRetrievalUrl state to kwicDataStore
- add downloadKwicArchive(format) action using POST /tools/kwic/archive
- replace downloadKWICTableExcel/CSV with async archive calls
- remove ExcelJS and JSZip client-side generation
- add copy-link button to kwicDataTable.vue via useClipboardCopy
- restore accidentally deleted downloadRetrievalPage i18n keys

Closes #191