### PR TITLE
fix(downloads): keep copy-link button visible after download completes

### DIFF
--- a/src/components/kwicDataTable.vue
+++ b/src/components/kwicDataTable.vue
@@ -266,10 +266,6 @@ const onRequest = async ({ pagination }) => {
   });
 };
 
-const getParamString = () => {
-  return metaStore.selectedMetadataToText("kwic");
-};
-
 const isDownloadActive = (downloadKey) =>
   downloadStore.isDownloadActive(downloadKey);
 

--- a/src/components/kwicDataTable.vue
+++ b/src/components/kwicDataTable.vue
@@ -71,6 +71,25 @@
           </q-item>
         </q-list>
       </q-btn-dropdown>
+
+      <q-btn
+        v-if="
+          kwicStore.archiveRetrievalUrl &&
+          (isDownloadActive(downloadKeys.excel) ||
+            isDownloadActive(downloadKeys.csv))
+        "
+        flat
+        no-caps
+        dense
+        icon="link"
+        class="q-ml-sm text-grey-7"
+        :label="
+          linkCopied
+            ? $t('downloadRetrievalPage.linkCopied')
+            : $t('downloadRetrievalPage.copyLink')
+        "
+        @click="copyRetrievalLink"
+      />
     </div>
     <q-table
       ref="KWICTable"
@@ -194,6 +213,7 @@ import { computed, ref } from "vue";
 import { metaDataStore } from "src/stores/metaDataStore";
 import { kwicDataStore } from "src/stores/kwicDataStore";
 import { downloadDataStore } from "src/stores/downloadDataStore";
+import { useClipboardCopy } from "src/composables/useClipboardCopy";
 import expandingTableRow from "src/components/expandingTableRow.vue";
 import loadingIcon from "src/components/loadingIcon.vue";
 import noResults from "src/components/noResults.vue";
@@ -201,6 +221,9 @@ import noResults from "src/components/noResults.vue";
 const metaStore = metaDataStore();
 const kwicStore = kwicDataStore();
 const downloadStore = downloadDataStore();
+const { linkCopied, copyToClipboard } = useClipboardCopy();
+
+const copyRetrievalLink = () => copyToClipboard(kwicStore.archiveRetrievalUrl);
 
 const downloadKeys = {
   csv: "kwic-csv",
@@ -253,7 +276,7 @@ const isDownloadActive = (downloadKey) =>
 const downloadKWICTableAsExcel = async () => {
   await downloadStore.runTrackedDownload(
     downloadKeys.excel,
-    () => kwicStore.downloadKWICTableExcel(getParamString()),
+    () => kwicStore.downloadKWICTableExcel(),
     {
       getErrorMessage: () => kwicStore.errorMessage,
     },
@@ -263,7 +286,7 @@ const downloadKWICTableAsExcel = async () => {
 const downloadKWICTableAsCSV = async () => {
   await downloadStore.runTrackedDownload(
     downloadKeys.csv,
-    () => kwicStore.downloadKWICTableCSV(getParamString()),
+    () => kwicStore.downloadKWICTableCSV(),
     {
       getErrorMessage: () => kwicStore.errorMessage,
     },

--- a/src/components/kwicDataTable.vue
+++ b/src/components/kwicDataTable.vue
@@ -73,11 +73,7 @@
       </q-btn-dropdown>
 
       <q-btn
-        v-if="
-          kwicStore.archiveRetrievalUrl &&
-          (isDownloadActive(downloadKeys.excel) ||
-            isDownloadActive(downloadKeys.csv))
-        "
+        v-if="kwicStore.archiveRetrievalUrl"
         flat
         no-caps
         dense

--- a/src/components/speechesTable.vue
+++ b/src/components/speechesTable.vue
@@ -78,10 +78,7 @@
           </q-list>
         </q-btn-dropdown>
         <q-btn
-          v-if="
-            downloadStore.archiveRetrievalUrl &&
-            isDownloadActive(downloadKeys.zip)
-          "
+          v-if="downloadStore.archiveRetrievalUrl"
           flat
           no-caps
           dense

--- a/src/components/speechesTable.vue
+++ b/src/components/speechesTable.vue
@@ -77,6 +77,23 @@
             </q-item>
           </q-list>
         </q-btn-dropdown>
+        <q-btn
+          v-if="
+            downloadStore.archiveRetrievalUrl &&
+            isDownloadActive(downloadKeys.zip)
+          "
+          flat
+          no-caps
+          dense
+          icon="link"
+          class="q-ml-sm text-grey-7"
+          :label="
+            linkCopied
+              ? $t('downloadRetrievalPage.linkCopied')
+              : $t('downloadRetrievalPage.copyLink')
+          "
+          @click="copyRetrievalLink"
+        />
       </div>
 
       <q-table
@@ -193,6 +210,20 @@ const downloadKeys = {
 };
 
 const SpeechTable = ref(null);
+const linkCopied = ref(false);
+
+const copyRetrievalLink = async () => {
+  if (!downloadStore.archiveRetrievalUrl) return;
+  try {
+    await navigator.clipboard.writeText(downloadStore.archiveRetrievalUrl);
+    linkCopied.value = true;
+    setTimeout(() => {
+      linkCopied.value = false;
+    }, 2000);
+  } catch {
+    // fallback: ignore clipboard errors silently
+  }
+};
 
 const pagination = computed({
   get: () => speechesStore.pagination,

--- a/src/components/speechesTable.vue
+++ b/src/components/speechesTable.vue
@@ -191,6 +191,7 @@
 <script setup>
 import { computed, ref } from "vue";
 import { api } from "boot/axios";
+import { useClipboardCopy } from "src/composables/useClipboardCopy.js";
 import i18n from "src/i18n/sv/index.js";
 import { metaDataStore } from "src/stores/metaDataStore.js";
 import { speechesDataStore } from "src/stores/speechesDataStore";
@@ -210,20 +211,9 @@ const downloadKeys = {
 };
 
 const SpeechTable = ref(null);
-const linkCopied = ref(false);
-
-const copyRetrievalLink = async () => {
-  if (!downloadStore.archiveRetrievalUrl) return;
-  try {
-    await navigator.clipboard.writeText(downloadStore.archiveRetrievalUrl);
-    linkCopied.value = true;
-    setTimeout(() => {
-      linkCopied.value = false;
-    }, 2000);
-  } catch {
-    // fallback: ignore clipboard errors silently
-  }
-};
+const { linkCopied, copyToClipboard } = useClipboardCopy();
+const copyRetrievalLink = () =>
+  copyToClipboard(downloadStore.archiveRetrievalUrl);
 
 const pagination = computed({
   get: () => speechesStore.pagination,

--- a/src/components/wordTrendsSpeechTable.vue
+++ b/src/components/wordTrendsSpeechTable.vue
@@ -78,9 +78,7 @@
           </q-list>
         </q-btn-dropdown>
         <q-btn
-          v-if="
-            wtStore.archiveRetrievalUrl && isDownloadActive(downloadKeys.zip)
-          "
+          v-if="wtStore.archiveRetrievalUrl"
           flat
           no-caps
           dense

--- a/src/components/wordTrendsSpeechTable.vue
+++ b/src/components/wordTrendsSpeechTable.vue
@@ -77,6 +77,22 @@
             </q-item>
           </q-list>
         </q-btn-dropdown>
+        <q-btn
+          v-if="
+            wtStore.archiveRetrievalUrl && isDownloadActive(downloadKeys.zip)
+          "
+          flat
+          no-caps
+          dense
+          icon="link"
+          class="q-ml-sm text-grey-7"
+          :label="
+            linkCopied
+              ? $t('downloadRetrievalPage.linkCopied')
+              : $t('downloadRetrievalPage.copyLink')
+          "
+          @click="copyRetrievalLink"
+        />
       </div>
 
       <q-table
@@ -197,6 +213,20 @@ const downloadKeys = {
 };
 
 const SpeechTable = ref(null);
+const linkCopied = ref(false);
+
+const copyRetrievalLink = async () => {
+  if (!wtStore.archiveRetrievalUrl) return;
+  try {
+    await navigator.clipboard.writeText(wtStore.archiveRetrievalUrl);
+    linkCopied.value = true;
+    setTimeout(() => {
+      linkCopied.value = false;
+    }, 2000);
+  } catch {
+    // fallback: ignore clipboard errors silently
+  }
+};
 
 const pagination = computed({
   get: () => wtStore.speechesPagination,

--- a/src/components/wordTrendsSpeechTable.vue
+++ b/src/components/wordTrendsSpeechTable.vue
@@ -195,6 +195,7 @@
 
 <script setup>
 import { computed, ref } from "vue";
+import { useClipboardCopy } from "src/composables/useClipboardCopy.js";
 import { downloadDataStore } from "src/stores/downloadDataStore";
 import { metaDataStore } from "src/stores/metaDataStore.js";
 import { wordTrendsDataStore } from "src/stores/wordTrendsDataStore";
@@ -213,20 +214,8 @@ const downloadKeys = {
 };
 
 const SpeechTable = ref(null);
-const linkCopied = ref(false);
-
-const copyRetrievalLink = async () => {
-  if (!wtStore.archiveRetrievalUrl) return;
-  try {
-    await navigator.clipboard.writeText(wtStore.archiveRetrievalUrl);
-    linkCopied.value = true;
-    setTimeout(() => {
-      linkCopied.value = false;
-    }, 2000);
-  } catch {
-    // fallback: ignore clipboard errors silently
-  }
-};
+const { linkCopied, copyToClipboard } = useClipboardCopy();
+const copyRetrievalLink = () => copyToClipboard(wtStore.archiveRetrievalUrl);
 
 const pagination = computed({
   get: () => wtStore.speechesPagination,

--- a/src/composables/useClipboardCopy.js
+++ b/src/composables/useClipboardCopy.js
@@ -1,0 +1,31 @@
+import { ref, onUnmounted } from "vue";
+
+export function useClipboardCopy() {
+  const linkCopied = ref(false);
+  let resetTimer = null;
+
+  const copyToClipboard = async (text) => {
+    if (!text) return;
+    try {
+      await navigator.clipboard.writeText(text);
+      if (resetTimer !== null) {
+        clearTimeout(resetTimer);
+      }
+      linkCopied.value = true;
+      resetTimer = setTimeout(() => {
+        linkCopied.value = false;
+        resetTimer = null;
+      }, 2000);
+    } catch {
+      // fallback: ignore clipboard errors silently
+    }
+  };
+
+  onUnmounted(() => {
+    if (resetTimer !== null) {
+      clearTimeout(resetTimer);
+    }
+  });
+
+  return { linkCopied, copyToClipboard };
+}

--- a/src/i18n/en-US/index.js
+++ b/src/i18n/en-US/index.js
@@ -13,6 +13,8 @@ export default {
     preparing: "Preparing download...",
     success: "The download has started.",
     error: "Could not start the download.",
+    archiveGenerationFailed: "Archive generation failed.",
+    archiveGenerationTimeout: "Archive generation timed out.",
   },
   accessibility: {
     loadingResults: "Loading results, please wait...",

--- a/src/i18n/en-US/index.js
+++ b/src/i18n/en-US/index.js
@@ -16,6 +16,22 @@ export default {
     archiveGenerationFailed: "Archive generation failed.",
     archiveGenerationTimeout: "Archive generation timed out.",
   },
+  downloadRetrievalPage: {
+    pending: "Preparing your archive…",
+    pendingHint:
+      "This page refreshes automatically. You can also bookmark this link and return later.",
+    readyTitle: "Your archive is ready",
+    readyDescription: "Click the button below to download your archive.",
+    expiresAt: "Available until:",
+    downloadButton: "Download archive",
+    failed: "Archive generation failed",
+    expiredTitle: "Link has expired",
+    expired:
+      "This archive link has expired or is no longer available. Please submit a new search to generate a new archive.",
+    backToSearch: "Back to search",
+    copyLink: "Copy retrieval link",
+    linkCopied: "Link copied!",
+  },
   accessibility: {
     loadingResults: "Loading results, please wait...",
     ticketExpired: "The results have expired. Please submit a new search.",

--- a/src/i18n/sv/index.js
+++ b/src/i18n/sv/index.js
@@ -192,6 +192,22 @@ export default {
     archiveGenerationFailed: "Arkivgenerering misslyckades.",
     archiveGenerationTimeout: "Tidsgränsen för arkivgenerering uppnåddes.",
   },
+  downloadRetrievalPage: {
+    pending: "Förbereder ditt arkiv…",
+    pendingHint:
+      "Sidan uppdateras automatiskt. Du kan bokmärka länken och återkomma senare.",
+    readyTitle: "Ditt arkiv är klart",
+    readyDescription: "Klicka på knappen nedan för att ladda ned ditt arkiv.",
+    expiresAt: "Tillgängligt till:",
+    downloadButton: "Ladda ned arkiv",
+    failed: "Arkivgenerering misslyckades",
+    expiredTitle: "Länken har gått ut",
+    expired:
+      "Den här arkivlänken har gått ut eller är inte längre tillgänglig. Gör en ny sökning för att generera ett nytt arkiv.",
+    backToSearch: "Tillbaka till sökning",
+    copyLink: "Kopiera hämtningslänk",
+    linkCopied: "Länk kopierad!",
+  },
 
   kwicLable: {
     left_word: "Vänster",

--- a/src/i18n/sv/index.js
+++ b/src/i18n/sv/index.js
@@ -189,6 +189,8 @@ export default {
     preparing: "Förbereder nedladdning...",
     success: "Nedladdningen har startat.",
     error: "Kunde inte starta nedladdningen.",
+    archiveGenerationFailed: "Arkivgenerering misslyckades.",
+    archiveGenerationTimeout: "Tidsgränsen för arkivgenerering uppnåddes.",
   },
 
   kwicLable: {

--- a/src/pages/DownloadRetrievalPage.vue
+++ b/src/pages/DownloadRetrievalPage.vue
@@ -92,7 +92,7 @@ import { api } from "boot/axios";
 const POLL_INTERVAL_MS = 5000;
 
 const route = useRoute();
-const archiveTicketId = route.params.archiveTicketId;
+const archiveTicketId = encodeURIComponent(route.params.archiveTicketId);
 
 const state = ref("pending"); // "pending" | "ready" | "failed" | "expired"
 const ticketStatus = ref(null);

--- a/src/pages/DownloadRetrievalPage.vue
+++ b/src/pages/DownloadRetrievalPage.vue
@@ -1,0 +1,187 @@
+<template>
+  <q-page class="q-px-md q-py-lg" style="max-width: 700px; margin: 0 auto">
+    <!-- PENDING state -->
+    <template v-if="state === 'pending'">
+      <div class="column items-center q-gutter-md q-py-xl">
+        <q-spinner-tail color="primary" size="64px" />
+        <q-item-label class="text-h6 text-center">
+          {{ $t("downloadRetrievalPage.pending") }}
+        </q-item-label>
+        <q-item-label caption class="text-center">
+          {{ $t("downloadRetrievalPage.pendingHint") }}
+        </q-item-label>
+      </div>
+    </template>
+
+    <!-- READY state -->
+    <template v-else-if="state === 'ready'">
+      <q-card flat bordered class="q-pa-lg">
+        <q-card-section>
+          <q-item-label class="text-h6 q-mb-sm">
+            {{ $t("downloadRetrievalPage.readyTitle") }}
+          </q-item-label>
+          <q-item-label class="q-mb-md">
+            {{ $t("downloadRetrievalPage.readyDescription") }}
+          </q-item-label>
+          <q-item-label v-if="ticketStatus?.expires_at" caption class="q-mb-lg">
+            {{ $t("downloadRetrievalPage.expiresAt") }}
+            {{ formattedExpiry }}
+          </q-item-label>
+        </q-card-section>
+        <q-card-actions vertical align="left">
+          <q-btn
+            color="primary"
+            icon="download"
+            no-caps
+            :label="$t('downloadRetrievalPage.downloadButton')"
+            :loading="isDownloading"
+            @click="triggerDownload"
+          />
+        </q-card-actions>
+      </q-card>
+    </template>
+
+    <!-- FAILED state -->
+    <template v-else-if="state === 'failed'">
+      <q-banner class="bg-negative text-white q-mb-md" rounded>
+        <template v-slot:avatar>
+          <q-icon name="error_outline" />
+        </template>
+        {{ $t("downloadRetrievalPage.failed") }}
+        <span v-if="errorDetail"> — {{ errorDetail }}</span>
+      </q-banner>
+      <q-btn
+        flat
+        no-caps
+        icon="arrow_back"
+        :to="'/'"
+        :label="$t('downloadRetrievalPage.backToSearch')"
+      />
+    </template>
+
+    <!-- EXPIRED / NOT FOUND state -->
+    <template v-else-if="state === 'expired'">
+      <q-card flat bordered class="q-pa-lg">
+        <q-card-section>
+          <q-item-label class="text-h6 q-mb-sm">
+            {{ $t("downloadRetrievalPage.expiredTitle") }}
+          </q-item-label>
+          <q-item-label>
+            {{ $t("downloadRetrievalPage.expired") }}
+          </q-item-label>
+        </q-card-section>
+        <q-card-actions>
+          <q-btn
+            flat
+            no-caps
+            icon="arrow_back"
+            :to="'/'"
+            :label="$t('downloadRetrievalPage.backToSearch')"
+          />
+        </q-card-actions>
+      </q-card>
+    </template>
+  </q-page>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, onUnmounted } from "vue";
+import { useRoute } from "vue-router";
+import { api } from "boot/axios";
+
+const POLL_INTERVAL_MS = 5000;
+
+const route = useRoute();
+const archiveTicketId = route.params.archiveTicketId;
+
+const state = ref("pending"); // "pending" | "ready" | "failed" | "expired"
+const ticketStatus = ref(null);
+const errorDetail = ref(null);
+const isDownloading = ref(false);
+
+let pollTimer = null;
+
+const formattedExpiry = computed(() => {
+  if (!ticketStatus.value?.expires_at) return "";
+  return new Date(ticketStatus.value.expires_at).toLocaleString();
+});
+
+async function fetchStatus() {
+  try {
+    const response = await api.get(`/downloads/${archiveTicketId}`);
+    ticketStatus.value = response.data;
+    const status = response.data.status;
+
+    if (status === "ready") {
+      state.value = "ready";
+      stopPolling();
+    } else if (status === "error") {
+      state.value = "failed";
+      errorDetail.value = response.data.error || null;
+      stopPolling();
+    } else {
+      // still pending — keep polling
+      state.value = "pending";
+    }
+  } catch (error) {
+    if (error.response?.status === 404) {
+      state.value = "expired";
+    } else {
+      state.value = "failed";
+      errorDetail.value =
+        error?.response?.data?.detail || error?.message || null;
+    }
+    stopPolling();
+  }
+}
+
+function startPolling() {
+  fetchStatus();
+  pollTimer = setInterval(fetchStatus, POLL_INTERVAL_MS);
+}
+
+function stopPolling() {
+  if (pollTimer !== null) {
+    clearInterval(pollTimer);
+    pollTimer = null;
+  }
+}
+
+async function triggerDownload() {
+  isDownloading.value = true;
+  try {
+    const response = await api.get(`/downloads/${archiveTicketId}/download`, {
+      responseType: "blob",
+    });
+    const disposition = response.headers["content-disposition"] || "";
+    const match = disposition.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/);
+    const filename = match
+      ? match[1].replace(/['"]/g, "")
+      : `archive_${archiveTicketId}.zip`;
+    const url = URL.createObjectURL(response.data);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    link.click();
+    URL.revokeObjectURL(url);
+  } catch (error) {
+    if (error.response?.status === 404 || error.response?.status === 410) {
+      state.value = "expired";
+    } else {
+      state.value = "failed";
+      errorDetail.value =
+        error?.response?.data?.detail || error?.message || null;
+    }
+  } finally {
+    isDownloading.value = false;
+  }
+}
+
+onMounted(() => {
+  startPolling();
+});
+
+onUnmounted(() => {
+  stopPolling();
+});
+</script>

--- a/src/pages/DownloadRetrievalPage.vue
+++ b/src/pages/DownloadRetrievalPage.vue
@@ -88,6 +88,7 @@
 import { ref, computed, onMounted, onUnmounted } from "vue";
 import { useRoute } from "vue-router";
 import { api } from "boot/axios";
+import { downloadDataStore } from "src/stores/downloadDataStore";
 
 const POLL_INTERVAL_MS = 5000;
 
@@ -162,17 +163,12 @@ async function triggerDownload() {
     const response = await api.get(`/downloads/${archiveTicketId}/download`, {
       responseType: "blob",
     });
-    const disposition = response.headers["content-disposition"] || "";
-    const match = disposition.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/);
-    const filename = match
-      ? match[1].replace(/['"]/g, "")
-      : `archive_${archiveTicketId}.zip`;
-    const url = URL.createObjectURL(response.data);
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = filename;
-    link.click();
-    URL.revokeObjectURL(url);
+    const store = downloadDataStore();
+    const filename = store.getFilenameFromDisposition(
+      response.headers,
+      `archive_${archiveTicketId}.zip`,
+    );
+    store.setupDownload(filename, response.data);
   } catch (error) {
     if (error.response?.status === 404 || error.response?.status === 410) {
       state.value = "expired";

--- a/src/pages/DownloadRetrievalPage.vue
+++ b/src/pages/DownloadRetrievalPage.vue
@@ -100,6 +100,7 @@ const errorDetail = ref(null);
 const isDownloading = ref(false);
 
 let pollTimer = null;
+let pollingActive = false;
 
 const formattedExpiry = computed(() => {
   if (!ticketStatus.value?.expires_at) return "";
@@ -135,14 +136,22 @@ async function fetchStatus() {
   }
 }
 
+async function schedulePoll() {
+  await fetchStatus();
+  if (pollingActive) {
+    pollTimer = setTimeout(schedulePoll, POLL_INTERVAL_MS);
+  }
+}
+
 function startPolling() {
-  fetchStatus();
-  pollTimer = setInterval(fetchStatus, POLL_INTERVAL_MS);
+  pollingActive = true;
+  schedulePoll();
 }
 
 function stopPolling() {
+  pollingActive = false;
   if (pollTimer !== null) {
-    clearInterval(pollTimer);
+    clearTimeout(pollTimer);
     pollTimer = null;
   }
 }

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -3,9 +3,11 @@ const routes = [
     path: "/",
     component: () => import("layouts/MainLayout.vue"),
     children: [
-
       { path: "pdf", component: () => import("pages/PdfPage.vue") },
-      { path: "pdf-pagewise", component: () => import("pages/PdfPageWise.vue") },
+      {
+        path: "pdf-pagewise",
+        component: () => import("pages/PdfPageWise.vue"),
+      },
 
       {
         path: "",
@@ -22,7 +24,11 @@ const routes = [
         component: () => import("pages/FAQPage.vue"),
         meta: { title: "FAQ" },
       },
-
+      {
+        path: "download/:archiveTicketId",
+        component: () => import("pages/DownloadRetrievalPage.vue"),
+        meta: { title: "Hämta arkiv" },
+      },
     ],
   },
   {

--- a/src/stores/__tests__/ticketPolling.spec.js
+++ b/src/stores/__tests__/ticketPolling.spec.js
@@ -1,10 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   getTicketPollDelayMs,
+  pollArchiveTicket,
   TICKET_POLL_INTERVAL_MS,
   TICKET_POLL_MAX_ATTEMPTS,
 } from "../ticketPolling";
+import i18n from "src/i18n/sv/index.js";
 
 describe("getTicketPollDelayMs", () => {
   it("uses Retry-After when the header is a positive integer", () => {
@@ -27,5 +29,173 @@ describe("getTicketPollDelayMs", () => {
 
   it("allows 180 seconds of polling when Retry-After is 2 seconds", () => {
     expect(TICKET_POLL_MAX_ATTEMPTS * 2).toBe(180);
+  });
+});
+
+describe("pollArchiveTicket", () => {
+  let api;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    api = { get: vi.fn() };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("success path", () => {
+    it("resolves immediately when the first poll returns ready", async () => {
+      const data = { status: "ready", download_url: "/files/archive.zip" };
+      api.get.mockResolvedValue({ data, headers: {} });
+
+      const result = await pollArchiveTicket(api, {
+        statusUrl: "/v1/tools/archive/abc/status",
+        maxAttempts: 3,
+      });
+
+      expect(api.get).toHaveBeenCalledOnce();
+      expect(api.get).toHaveBeenCalledWith("/v1/tools/archive/abc/status");
+      expect(result).toEqual(data);
+    });
+
+    it("resolves after a pending response followed by ready", async () => {
+      api.get
+        .mockResolvedValueOnce({ data: { status: "pending" }, headers: {} })
+        .mockResolvedValueOnce({
+          data: { status: "ready", download_url: "/files/archive.zip" },
+          headers: {},
+        });
+
+      const promise = pollArchiveTicket(api, {
+        statusUrl: "/v1/tools/archive/abc/status",
+        maxAttempts: 5,
+      });
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      expect(api.get).toHaveBeenCalledTimes(2);
+      expect(result.status).toBe("ready");
+    });
+  });
+
+  describe("error path", () => {
+    it("throws with the server error message when status is error", async () => {
+      api.get.mockResolvedValue({
+        data: { status: "error", error: "Disk full" },
+        headers: {},
+      });
+
+      await expect(
+        pollArchiveTicket(api, { statusUrl: "/v1/tools/archive/abc/status" }),
+      ).rejects.toThrow("Disk full");
+    });
+
+    it("falls back to the i18n message when error status has no message", async () => {
+      api.get.mockResolvedValue({ data: { status: "error" }, headers: {} });
+
+      await expect(
+        pollArchiveTicket(api, { statusUrl: "/v1/tools/archive/abc/status" }),
+      ).rejects.toThrow(i18n.downloadFeedback.archiveGenerationFailed);
+    });
+  });
+
+  describe("max-attempts timeout", () => {
+    it("throws the i18n timeout message after exhausting max attempts", async () => {
+      api.get.mockResolvedValue({ data: { status: "pending" }, headers: {} });
+
+      const promise = pollArchiveTicket(api, {
+        statusUrl: "/v1/tools/archive/abc/status",
+        maxAttempts: 2,
+      });
+      // Attach the rejection handler before advancing timers so the rejection
+      // is handled the moment it occurs and does not become an unhandled rejection.
+      const assertion = expect(promise).rejects.toThrow(
+        i18n.downloadFeedback.archiveGenerationTimeout,
+      );
+      await vi.runAllTimersAsync();
+      await assertion;
+      expect(api.get).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("onStatus callback", () => {
+    it("calls onStatus with each polled status string in order", async () => {
+      const onStatus = vi.fn();
+      api.get
+        .mockResolvedValueOnce({ data: { status: "pending" }, headers: {} })
+        .mockResolvedValueOnce({ data: { status: "ready" }, headers: {} });
+
+      const promise = pollArchiveTicket(api, {
+        statusUrl: "/v1/tools/archive/abc/status",
+        maxAttempts: 5,
+        onStatus,
+      });
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(onStatus).toHaveBeenCalledTimes(2);
+      expect(onStatus).toHaveBeenNthCalledWith(1, "pending");
+      expect(onStatus).toHaveBeenNthCalledWith(2, "ready");
+    });
+  });
+
+  describe("Retry-After backoff", () => {
+    it("waits the Retry-After header duration before the next poll", async () => {
+      api.get
+        .mockResolvedValueOnce({
+          data: { status: "pending" },
+          headers: { "retry-after": "5" },
+        })
+        .mockResolvedValueOnce({ data: { status: "ready" }, headers: {} });
+
+      const promise = pollArchiveTicket(api, {
+        statusUrl: "/v1/tools/archive/abc/status",
+        maxAttempts: 3,
+      });
+
+      // First api.get is initiated synchronously when the async function starts.
+      expect(api.get).toHaveBeenCalledTimes(1);
+
+      // Drain the first awaited resolution so the 5 s setTimeout is scheduled.
+      await vi.advanceTimersByTimeAsync(0);
+
+      // 4 999 ms elapsed — the 5 s Retry-After timer has not yet fired.
+      await vi.advanceTimersByTimeAsync(4999);
+      expect(api.get).toHaveBeenCalledTimes(1);
+
+      // 5 000 ms total — timer fires, second poll executes.
+      await vi.advanceTimersByTimeAsync(1);
+      const result = await promise;
+
+      expect(api.get).toHaveBeenCalledTimes(2);
+      expect(result.status).toBe("ready");
+    });
+
+    it("waits the default interval when Retry-After header is absent", async () => {
+      api.get
+        .mockResolvedValueOnce({ data: { status: "pending" }, headers: {} })
+        .mockResolvedValueOnce({ data: { status: "ready" }, headers: {} });
+
+      const promise = pollArchiveTicket(api, {
+        statusUrl: "/v1/tools/archive/abc/status",
+        maxAttempts: 3,
+      });
+
+      expect(api.get).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      // One millisecond short of the default interval — still waiting.
+      await vi.advanceTimersByTimeAsync(TICKET_POLL_INTERVAL_MS - 1);
+      expect(api.get).toHaveBeenCalledTimes(1);
+
+      // Default interval elapsed — second poll executes.
+      await vi.advanceTimersByTimeAsync(1);
+      const result = await promise;
+
+      expect(api.get).toHaveBeenCalledTimes(2);
+      expect(result.status).toBe("ready");
+    });
   });
 });

--- a/src/stores/downloadDataStore.js
+++ b/src/stores/downloadDataStore.js
@@ -4,15 +4,23 @@ import { Notify } from "quasar";
 import JSZip from "jszip";
 import i18n from "src/i18n/sv/index.js";
 import { metaDataStore } from "./metaDataStore";
+import { pollArchiveTicket } from "./ticketPolling";
 
 export const downloadDataStore = defineStore("downloadData", {
   state: () => ({
     activeDownloads: {},
+    archiveTicketId: null,
+    archiveTicketStatus: null,
   }),
 
   actions: {
     isDownloadActive(downloadKey) {
       return Boolean(this.activeDownloads[downloadKey]);
+    },
+
+    resetArchiveTicketState() {
+      this.archiveTicketId = null;
+      this.archiveTicketStatus = null;
     },
 
     setDownloadActive(downloadKey, isActive) {
@@ -255,26 +263,37 @@ export const downloadDataStore = defineStore("downloadData", {
     },
 
     async downloadSpeechesZipByTicket(ticketId) {
-      try {
-        const response = await api.get(
-          `/tools/speeches/archive/${encodeURIComponent(ticketId)}`,
-          {
-            responseType: "blob",
-          },
-        );
+      this.resetArchiveTicketState();
 
-        this.setupDownload(
-          this.getFilenameFromDisposition(
-            response.headers,
-            `speeches_${ticketId}.zip`,
-          ),
-          response.data,
-        );
-        return true;
-      } catch (error) {
-        console.error("Error fetching ticket download:", error);
-        throw error;
-      }
+      // 1. Request archive ticket
+      const prepareResponse = await api.post(
+        `/tools/speeches/archive/${encodeURIComponent(ticketId)}?archive_format=zip`,
+      );
+      const archiveTicketId = prepareResponse.data.archive_ticket_id;
+      this.archiveTicketId = archiveTicketId;
+      this.archiveTicketStatus = "pending";
+
+      // 2. Poll until ready
+      await pollArchiveTicket(api, {
+        statusUrl: `/tools/speeches/archive/status/${archiveTicketId}`,
+        onStatus: (status) => {
+          this.archiveTicketStatus = status;
+        },
+      });
+
+      // 3. Download the artifact
+      const downloadResponse = await api.get(
+        `/tools/speeches/archive/download/${archiveTicketId}`,
+        { responseType: "blob" },
+      );
+      this.setupDownload(
+        this.getFilenameFromDisposition(
+          downloadResponse.headers,
+          `speeches_${ticketId}.zip`,
+        ),
+        downloadResponse.data,
+      );
+      return true;
     },
   },
 });

--- a/src/stores/downloadDataStore.js
+++ b/src/stores/downloadDataStore.js
@@ -11,6 +11,7 @@ export const downloadDataStore = defineStore("downloadData", {
     activeDownloads: {},
     archiveTicketId: null,
     archiveTicketStatus: null,
+    archiveRetrievalUrl: null,
   }),
 
   actions: {
@@ -21,6 +22,7 @@ export const downloadDataStore = defineStore("downloadData", {
     resetArchiveTicketState() {
       this.archiveTicketId = null;
       this.archiveTicketStatus = null;
+      this.archiveRetrievalUrl = null;
     },
 
     setDownloadActive(downloadKey, isActive) {
@@ -273,6 +275,7 @@ export const downloadDataStore = defineStore("downloadData", {
         const archiveTicketId = prepareResponse.data.archive_ticket_id;
         this.archiveTicketId = archiveTicketId;
         this.archiveTicketStatus = "pending";
+        this.archiveRetrievalUrl = prepareResponse.data.retrieval_url || null;
 
         // 2. Poll until ready
         await pollArchiveTicket(api, {

--- a/src/stores/downloadDataStore.js
+++ b/src/stores/downloadDataStore.js
@@ -265,35 +265,41 @@ export const downloadDataStore = defineStore("downloadData", {
     async downloadSpeechesZipByTicket(ticketId) {
       this.resetArchiveTicketState();
 
-      // 1. Request archive ticket
-      const prepareResponse = await api.post(
-        `/tools/speeches/archive/${encodeURIComponent(ticketId)}?archive_format=zip`,
-      );
-      const archiveTicketId = prepareResponse.data.archive_ticket_id;
-      this.archiveTicketId = archiveTicketId;
-      this.archiveTicketStatus = "pending";
+      try {
+        // 1. Request archive ticket
+        const prepareResponse = await api.post(
+          `/tools/speeches/archive/${encodeURIComponent(ticketId)}?archive_format=zip`,
+        );
+        const archiveTicketId = prepareResponse.data.archive_ticket_id;
+        this.archiveTicketId = archiveTicketId;
+        this.archiveTicketStatus = "pending";
 
-      // 2. Poll until ready
-      await pollArchiveTicket(api, {
-        statusUrl: `/tools/speeches/archive/status/${archiveTicketId}`,
-        onStatus: (status) => {
-          this.archiveTicketStatus = status;
-        },
-      });
+        // 2. Poll until ready
+        await pollArchiveTicket(api, {
+          statusUrl: `/tools/speeches/archive/status/${archiveTicketId}`,
+          onStatus: (status) => {
+            this.archiveTicketStatus = status;
+          },
+        });
 
-      // 3. Download the artifact
-      const downloadResponse = await api.get(
-        `/tools/speeches/archive/download/${archiveTicketId}`,
-        { responseType: "blob" },
-      );
-      this.setupDownload(
-        this.getFilenameFromDisposition(
-          downloadResponse.headers,
-          `speeches_${ticketId}.zip`,
-        ),
-        downloadResponse.data,
-      );
-      return true;
+        // 3. Download the artifact
+        const downloadResponse = await api.get(
+          `/tools/speeches/archive/download/${archiveTicketId}`,
+          { responseType: "blob" },
+        );
+        this.setupDownload(
+          this.getFilenameFromDisposition(
+            downloadResponse.headers,
+            `speeches_${ticketId}.zip`,
+          ),
+          downloadResponse.data,
+        );
+        return true;
+      } catch (error) {
+        console.error("Error downloading speeches zip by ticket:", error);
+        this.resetArchiveTicketState();
+        return false;
+      }
     },
   },
 });

--- a/src/stores/kwicDataStore.js
+++ b/src/stores/kwicDataStore.js
@@ -330,50 +330,12 @@ export const kwicDataStore = defineStore("kwicData", {
       }
     },
 
-    async fetchKwicExportData() {
-      if (this.useTicketFlow && this.ticketId) {
-        const response = await api.get(
-          `/tools/kwic/download/${this.ticketId}`,
-          {
-            params: { format: "json" },
-            responseType: "blob",
-          },
-        );
-        return downloadDataStore().extractJsonPayloadFromZip(response.data);
-      }
-
-      const normalizedSearch = this.normalizeSearch(this.searchText);
-
-      if (!normalizedSearch) {
-        return [];
-      }
-
-      const path = this.getKwicResultsPath(normalizedSearch);
-      const additionalParams = {
-        words_before: this.wordsLeft,
-        words_after: this.wordsRight,
-        lemmatized: this.lemmatizeSearch,
-        ...(this.cutOff !== null && { cut_off: this.cutOff }),
-      };
-      const queryString = metaDataStore().getSelectedParamsAtSearch(
-        "kwic",
-        additionalParams,
-      );
-      const response = await api.get(`${path}?${queryString}`);
-
-      return response.data.kwic_list || [];
-    },
-
-    async getExportRows() {
-      if (this.useTicketFlow && this.ticketId) {
-        return this.fetchKwicExportData();
-      }
-
-      return this.kwicData || [];
-    },
-
     async downloadKwicArchive(format = "jsonl_gz") {
-      if (!this.ticketId) return false;
+      if (!this.ticketId) {
+        this.archiveRetrievalUrl = null;
+        this.errorMessage = i18n.accessibility.ticketExpired;
+        return false;
+      }
       this.errorMessage = "";
       this.archiveRetrievalUrl = null;
 
@@ -395,10 +357,12 @@ export const kwicDataStore = defineStore("kwicData", {
           `/downloads/${archiveTicketId}/download`,
           { responseType: "blob" },
         );
+        const archiveExtensions = { csv_gz: "csv.gz", jsonl_gz: "jsonl.gz" };
+        const fileExtension = archiveExtensions[format] ?? format;
         downloadDataStore().setupDownload(
           downloadDataStore().getFilenameFromDisposition(
             downloadResponse.headers,
-            `kwic_archive_${this.ticketId}.${format}`,
+            `kwic_archive_${this.ticketId}.${fileExtension}`,
           ),
           downloadResponse.data,
         );

--- a/src/stores/kwicDataStore.js
+++ b/src/stores/kwicDataStore.js
@@ -3,11 +3,10 @@ import { api } from "boot/axios";
 import axios from "axios";
 import { metaDataStore } from "./metaDataStore";
 import { downloadDataStore } from "./downloadDataStore";
-import JSZip from "jszip";
-import ExcelJS from "exceljs";
 import i18n from "src/i18n/sv/index.js";
 import {
   getTicketPollDelayMs,
+  pollArchiveTicket,
   TICKET_POLL_MAX_ATTEMPTS,
 } from "./ticketPolling";
 
@@ -52,6 +51,7 @@ export const kwicDataStore = defineStore("kwicData", {
     expiresAt: null,
     errorMessage: "",
     hasSubmittedQuery: false,
+    archiveRetrievalUrl: null,
     isLoading: false,
     isPageLoading: false,
     requestSequence: 0,
@@ -92,6 +92,7 @@ export const kwicDataStore = defineStore("kwicData", {
       this.totalHits = 0;
       this.totalPages = 0;
       this.expiresAt = null;
+      this.archiveRetrievalUrl = null;
       this.pagination = {
         ...this.pagination,
         page: 1,
@@ -371,44 +372,36 @@ export const kwicDataStore = defineStore("kwicData", {
       return this.kwicData || [];
     },
 
-    async downloadKWICTableExcel(selectedMetadata) {
+    async downloadKwicArchive(format = "jsonl_gz") {
+      if (!this.ticketId) return false;
       this.errorMessage = "";
+      this.archiveRetrievalUrl = null;
 
       try {
-        const exportRows = await this.getExportRows();
+        // 1. Request archive ticket
+        const prepareResponse = await api.post(
+          `/tools/kwic/archive/${encodeURIComponent(this.ticketId)}?archive_format=${encodeURIComponent(format)}`,
+        );
+        const archiveTicketId = prepareResponse.data.archive_ticket_id;
+        this.archiveRetrievalUrl = prepareResponse.data.retrieval_url || null;
 
-        if (exportRows.length === 0) {
-          this.errorMessage =
-            i18n.downloadFeedback?.error || "Kunde inte starta nedladdningen.";
-          return false;
-        }
-
-        const data = exportRows.map((obj) => {
-          let newObj = {};
-          Object.keys(this.columnNames).forEach((key) => {
-            newObj[this.columnNames[key]] = obj[key] ?? "";
-          });
-          return newObj;
+        // 2. Poll until ready via generic downloads endpoint
+        await pollArchiveTicket(api, {
+          statusUrl: `/downloads/${archiveTicketId}`,
         });
 
-        const workbook = new ExcelJS.Workbook();
-        const worksheet = workbook.addWorksheet("Sheet1");
-
-        worksheet.columns = Object.values(this.columnNames).map((header) => ({
-          header,
-          key: header,
-        }));
-
-        data.forEach((row) => worksheet.addRow(row));
-
-        const buffer = await workbook.xlsx.writeBuffer();
-
-        const zip = new JSZip();
-        zip.file("kwicData.xlsx", buffer);
-        zip.file("metadata.txt", selectedMetadata);
-
-        const content = await zip.generateAsync({ type: "blob" });
-        downloadDataStore().setupDownload("kwicExcel.zip", content);
+        // 3. Download the artifact
+        const downloadResponse = await api.get(
+          `/downloads/${archiveTicketId}/download`,
+          { responseType: "blob" },
+        );
+        downloadDataStore().setupDownload(
+          downloadDataStore().getFilenameFromDisposition(
+            downloadResponse.headers,
+            `kwic_archive_${this.ticketId}.${format}`,
+          ),
+          downloadResponse.data,
+        );
         return true;
       } catch (error) {
         if (error.response?.status === 404) {
@@ -417,54 +410,17 @@ export const kwicDataStore = defineStore("kwicData", {
         } else {
           this.errorMessage = this.getErrorMessage(error);
         }
-        console.error("Error downloading KWIC Excel:", error);
+        console.error("Error downloading KWIC archive:", error);
         return false;
       }
     },
 
-    async downloadKWICTableCSV(selectedMetadata) {
-      this.errorMessage = "";
+    async downloadKWICTableExcel() {
+      return this.downloadKwicArchive("xlsx");
+    },
 
-      try {
-        const exportRows = await this.getExportRows();
-
-        if (exportRows.length === 0) {
-          this.errorMessage =
-            i18n.downloadFeedback?.error || "Kunde inte starta nedladdningen.";
-          return false;
-        }
-
-        const headerRow = Object.values(this.columnNames).join(",");
-
-        const dataRows = exportRows
-          .map((obj) =>
-            Object.keys(this.columnNames)
-              .map(
-                (key) => `"${(obj[key] ?? "").toString().replace(/"/g, '""')}"`,
-              )
-              .join(","),
-          )
-          .join("\n");
-
-        const csvContent = headerRow + "\n" + dataRows;
-
-        const zip = new JSZip();
-        zip.file("kwicData.csv", csvContent);
-        zip.file("metadata.txt", selectedMetadata);
-
-        const content = await zip.generateAsync({ type: "blob" });
-        downloadDataStore().setupDownload("kwicCSV.zip", content);
-        return true;
-      } catch (error) {
-        if (error.response?.status === 404) {
-          this.errorMessage = i18n.accessibility.ticketExpired;
-          this.resetTicketState();
-        } else {
-          this.errorMessage = this.getErrorMessage(error);
-        }
-        console.error("Error downloading KWIC CSV:", error);
-        return false;
-      }
+    async downloadKWICTableCSV() {
+      return this.downloadKwicArchive("csv_gz");
     },
   },
 });

--- a/src/stores/ticketPolling.js
+++ b/src/stores/ticketPolling.js
@@ -1,3 +1,5 @@
+import i18n from "src/i18n/sv/index.js";
+
 export const TICKET_POLL_INTERVAL_MS = 2000;
 export const TICKET_POLL_MAX_ATTEMPTS = 90;
 
@@ -34,7 +36,7 @@ export async function pollArchiveTicket(
 
     if (status === "ready") return response.data;
     if (status === "error")
-      throw new Error(error || "Archive generation failed");
+      throw new Error(error || i18n.downloadFeedback?.archiveGenerationFailed);
 
     const delayMs = getTicketPollDelayMs(
       attempt,
@@ -42,5 +44,5 @@ export async function pollArchiveTicket(
     );
     await new Promise((resolve) => setTimeout(resolve, delayMs));
   }
-  throw new Error("Tidsgränsen för arkivgenerering uppnåddes.");
+  throw new Error(i18n.downloadFeedback?.archiveGenerationTimeout);
 }

--- a/src/stores/ticketPolling.js
+++ b/src/stores/ticketPolling.js
@@ -10,3 +10,37 @@ export function getTicketPollDelayMs(attempt, retryAfterHeader) {
 
   return TICKET_POLL_INTERVAL_MS;
 }
+
+/**
+ * Poll an archive-ticket status endpoint until the ticket is ready or fails.
+ *
+ * @param {import('axios').AxiosInstance} api - The axios instance to use.
+ * @param {object} options
+ * @param {string} options.statusUrl - URL of the archive status endpoint.
+ * @param {number} [options.maxAttempts] - Maximum poll attempts before timeout.
+ * @param {function} [options.onStatus] - Called with the status string on each poll.
+ * @returns {Promise<object>} Resolves with the final status response data when ready.
+ * @throws {Error} If the ticket enters an error state or the poll limit is reached.
+ */
+export async function pollArchiveTicket(
+  api,
+  { statusUrl, maxAttempts = TICKET_POLL_MAX_ATTEMPTS, onStatus } = {},
+) {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const response = await api.get(statusUrl);
+    const { status, error } = response.data;
+
+    if (onStatus) onStatus(status);
+
+    if (status === "ready") return response.data;
+    if (status === "error")
+      throw new Error(error || "Archive generation failed");
+
+    const delayMs = getTicketPollDelayMs(
+      attempt,
+      response.headers?.["retry-after"],
+    );
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+  throw new Error("Tidsgränsen för arkivgenerering uppnåddes.");
+}

--- a/src/stores/wordTrendsDataStore.js
+++ b/src/stores/wordTrendsDataStore.js
@@ -39,6 +39,7 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
     // Archive ticket state
     archiveTicketId: null,
     archiveTicketStatus: null,
+    archiveRetrievalUrl: null,
     speechesTotalHits: 0,
     speechesTotalPages: 0,
     speechesErrorMessage: "",
@@ -120,6 +121,7 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
     resetArchiveTicketState() {
       this.archiveTicketId = null;
       this.archiveTicketStatus = null;
+      this.archiveRetrievalUrl = null;
     },
 
     async waitForSpeechesTicketReady(requestId) {
@@ -363,6 +365,7 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
         const archiveTicketId = prepareResponse.data.archive_ticket_id;
         this.archiveTicketId = archiveTicketId;
         this.archiveTicketStatus = "pending";
+        this.archiveRetrievalUrl = prepareResponse.data.retrieval_url || null;
 
         // 2. Poll until ready
         await pollArchiveTicket(api, {

--- a/src/stores/wordTrendsDataStore.js
+++ b/src/stores/wordTrendsDataStore.js
@@ -9,6 +9,7 @@ import i18n from "src/i18n/sv/index.js";
 import {
   getTicketPollDelayMs,
   TICKET_POLL_MAX_ATTEMPTS,
+  pollArchiveTicket,
 } from "./ticketPolling";
 
 const DEFAULT_PAGE_SIZE = 50;
@@ -35,6 +36,9 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
     // Ticket-based speeches state
     ticketId: null,
     ticketStatus: null,
+    // Archive ticket state
+    archiveTicketId: null,
+    archiveTicketStatus: null,
     speechesTotalHits: 0,
     speechesTotalPages: 0,
     speechesErrorMessage: "",
@@ -111,6 +115,11 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
         page: 1,
         rowsNumber: 0,
       };
+    },
+
+    resetArchiveTicketState() {
+      this.archiveTicketId = null;
+      this.archiveTicketStatus = null;
     },
 
     async waitForSpeechesTicketReady(requestId) {
@@ -344,18 +353,36 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
     async downloadSpeechesZip() {
       if (!this.ticketId) return false;
       this.speechesErrorMessage = "";
+      this.resetArchiveTicketState();
 
       try {
-        const response = await api.get(
-          `/tools/word_trend_speeches/archive/${encodeURIComponent(this.ticketId)}`,
+        // 1. Request archive ticket
+        const prepareResponse = await api.post(
+          `/tools/word_trend_speeches/archive/${encodeURIComponent(this.ticketId)}?archive_format=zip`,
+        );
+        const archiveTicketId = prepareResponse.data.archive_ticket_id;
+        this.archiveTicketId = archiveTicketId;
+        this.archiveTicketStatus = "pending";
+
+        // 2. Poll until ready
+        await pollArchiveTicket(api, {
+          statusUrl: `/tools/word_trend_speeches/archive/status/${archiveTicketId}`,
+          onStatus: (status) => {
+            this.archiveTicketStatus = status;
+          },
+        });
+
+        // 3. Download the artifact
+        const downloadResponse = await api.get(
+          `/tools/word_trend_speeches/archive/download/${archiveTicketId}`,
           { responseType: "blob" },
         );
         downloadDataStore().setupDownload(
           downloadDataStore().getFilenameFromDisposition(
-            response.headers,
+            downloadResponse.headers,
             `word_trend_speeches_archive_${this.ticketId}.zip`,
           ),
-          response.data,
+          downloadResponse.data,
         );
         return true;
       } catch (error) {


### PR DESCRIPTION
The button's v-if required isDownloadActive() to be true, but runTrackedDownload clears that flag in its finally block as soon as the task finishes. For large archives (e.g. ~1.5 GB word-trend speeches) this caused the retrieval URL to vanish at exactly the wrong moment.

Remove the isDownloadActive guard from the button in all three components. archiveRetrievalUrl is already cleared by resetArchiveTicketState() at the start of each new download, so stale links are not a concern.

Closes #193