### PR TITLE
feat(word-trends): add jsonl.gz and csv.gz speech archive download options

### DIFF
--- a/src/components/kwicDataTable.vue
+++ b/src/components/kwicDataTable.vue
@@ -73,7 +73,7 @@
       </q-btn-dropdown>
 
       <q-btn
-        v-if="kwicStore.archiveRetrievalUrl"
+        v-if="kwicStore.archiveTicketId"
         flat
         no-caps
         dense
@@ -219,7 +219,8 @@ const kwicStore = kwicDataStore();
 const downloadStore = downloadDataStore();
 const { linkCopied, copyToClipboard } = useClipboardCopy();
 
-const copyRetrievalLink = () => copyToClipboard(kwicStore.archiveRetrievalUrl);
+const copyRetrievalLink = () =>
+  copyToClipboard(window.location.origin + '/download/' + kwicStore.archiveTicketId);
 
 const downloadKeys = {
   csv: "kwic-csv",

--- a/src/components/speechesTable.vue
+++ b/src/components/speechesTable.vue
@@ -78,7 +78,7 @@
           </q-list>
         </q-btn-dropdown>
         <q-btn
-          v-if="downloadStore.archiveRetrievalUrl"
+          v-if="downloadStore.archiveTicketId"
           flat
           no-caps
           dense
@@ -210,7 +210,7 @@ const downloadKeys = {
 const SpeechTable = ref(null);
 const { linkCopied, copyToClipboard } = useClipboardCopy();
 const copyRetrievalLink = () =>
-  copyToClipboard(downloadStore.archiveRetrievalUrl);
+  copyToClipboard(window.location.origin + '/download/' + downloadStore.archiveTicketId);
 
 const pagination = computed({
   get: () => speechesStore.pagination,

--- a/src/components/wordTrendsSpeechTable.vue
+++ b/src/components/wordTrendsSpeechTable.vue
@@ -75,6 +75,40 @@
                 </q-item-label>
               </q-item-section>
             </q-item>
+            <q-item
+              clickable
+              v-close-popup
+              :disable="isDownloadActive(downloadKeys.jsonlgz)"
+              @click="downloadJsonlGz"
+            >
+              <q-item-section>
+                <q-item-label class="row items-center no-wrap">
+                  <q-spinner-tail
+                    v-if="isDownloadActive(downloadKeys.jsonlgz)"
+                    size="16px"
+                    class="q-mr-sm"
+                  />
+                  {{ $t("downloadSpeechJsonlGzArchive") }}
+                </q-item-label>
+              </q-item-section>
+            </q-item>
+            <q-item
+              clickable
+              v-close-popup
+              :disable="isDownloadActive(downloadKeys.csvgz)"
+              @click="downloadCsvGz"
+            >
+              <q-item-section>
+                <q-item-label class="row items-center no-wrap">
+                  <q-spinner-tail
+                    v-if="isDownloadActive(downloadKeys.csvgz)"
+                    size="16px"
+                    class="q-mr-sm"
+                  />
+                  {{ $t("downloadSpeechCsvGzArchive") }}
+                </q-item-label>
+              </q-item-section>
+            </q-item>
           </q-list>
         </q-btn-dropdown>
         <q-btn
@@ -209,6 +243,8 @@ const downloadKeys = {
   csv: "word-trends-speeches-csv",
   excel: "word-trends-speeches-excel",
   zip: "word-trends-speeches-zip",
+  jsonlgz: "word-trends-speeches-jsonlgz",
+  csvgz: "word-trends-speeches-csvgz",
 };
 
 const SpeechTable = ref(null);
@@ -274,6 +310,26 @@ const downloadZip = async () => {
   await downloadStore.runTrackedDownload(
     downloadKeys.zip,
     () => wtStore.downloadSpeechesZip(),
+    {
+      getErrorMessage: () => wtStore.speechesErrorMessage,
+    },
+  );
+};
+
+const downloadJsonlGz = async () => {
+  await downloadStore.runTrackedDownload(
+    downloadKeys.jsonlgz,
+    () => wtStore.downloadSpeechesJsonlGz(),
+    {
+      getErrorMessage: () => wtStore.speechesErrorMessage,
+    },
+  );
+};
+
+const downloadCsvGz = async () => {
+  await downloadStore.runTrackedDownload(
+    downloadKeys.csvgz,
+    () => wtStore.downloadSpeechesCsvGz(),
     {
       getErrorMessage: () => wtStore.speechesErrorMessage,
     },

--- a/src/components/wordTrendsSpeechTable.vue
+++ b/src/components/wordTrendsSpeechTable.vue
@@ -78,7 +78,7 @@
           </q-list>
         </q-btn-dropdown>
         <q-btn
-          v-if="wtStore.archiveRetrievalUrl"
+          v-if="wtStore.archiveTicketId"
           flat
           no-caps
           dense
@@ -213,7 +213,8 @@ const downloadKeys = {
 
 const SpeechTable = ref(null);
 const { linkCopied, copyToClipboard } = useClipboardCopy();
-const copyRetrievalLink = () => copyToClipboard(wtStore.archiveRetrievalUrl);
+const copyRetrievalLink = () =>
+  copyToClipboard(window.location.origin + '/download/' + wtStore.archiveTicketId);
 
 const pagination = computed({
   get: () => wtStore.speechesPagination,

--- a/src/i18n/en-US/index.js
+++ b/src/i18n/en-US/index.js
@@ -8,6 +8,8 @@ export default {
   downloadSpeechCsvArchive: "Download CSV archive (.zip)",
   downloadSpeechJsonArchive: "Download JSON archive (.zip)",
   downloadSpeechTextArchive: "Download speeches (.zip)",
+  downloadSpeechJsonlGzArchive: "Download speeches (.jsonl.gz)",
+  downloadSpeechCsvGzArchive: "Download speeches (.csv.gz)",
   downloadSpeech: "Download speeches",
   downloadFeedback: {
     preparing: "Preparing download...",

--- a/src/i18n/sv/index.js
+++ b/src/i18n/sv/index.js
@@ -185,6 +185,8 @@ export default {
   downloadSpeechJsonArchive: "Ladda ner JSON-arkiv (.zip)",
   downloadExcel: "Ladda ner Excel",
   downloadSpeechTextArchive: "Ladda ner tal (.zip)",
+  downloadSpeechJsonlGzArchive: "Ladda ner tal (.jsonl.gz)",
+  downloadSpeechCsvGzArchive: "Ladda ner tal (.csv.gz)",
   downloadFeedback: {
     preparing: "Förbereder nedladdning...",
     success: "Nedladdningen har startat.",

--- a/src/stores/kwicDataStore.js
+++ b/src/stores/kwicDataStore.js
@@ -51,6 +51,7 @@ export const kwicDataStore = defineStore("kwicData", {
     expiresAt: null,
     errorMessage: "",
     hasSubmittedQuery: false,
+    archiveTicketId: null,
     archiveRetrievalUrl: null,
     isLoading: false,
     isPageLoading: false,
@@ -92,6 +93,7 @@ export const kwicDataStore = defineStore("kwicData", {
       this.totalHits = 0;
       this.totalPages = 0;
       this.expiresAt = null;
+      this.archiveTicketId = null;
       this.archiveRetrievalUrl = null;
       this.pagination = {
         ...this.pagination,
@@ -332,11 +334,13 @@ export const kwicDataStore = defineStore("kwicData", {
 
     async downloadKwicArchive(format = "jsonl_gz") {
       if (!this.ticketId) {
+        this.archiveTicketId = null;
         this.archiveRetrievalUrl = null;
         this.errorMessage = i18n.accessibility.ticketExpired;
         return false;
       }
       this.errorMessage = "";
+      this.archiveTicketId = null;
       this.archiveRetrievalUrl = null;
 
       try {
@@ -345,6 +349,7 @@ export const kwicDataStore = defineStore("kwicData", {
           `/tools/kwic/archive/${encodeURIComponent(this.ticketId)}?archive_format=${encodeURIComponent(format)}`,
         );
         const archiveTicketId = prepareResponse.data.archive_ticket_id;
+        this.archiveTicketId = archiveTicketId;
         this.archiveRetrievalUrl = prepareResponse.data.retrieval_url || null;
 
         // 2. Poll until ready via generic downloads endpoint

--- a/src/stores/wordTrendsDataStore.js
+++ b/src/stores/wordTrendsDataStore.js
@@ -352,7 +352,7 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
       }
     },
 
-    async downloadSpeechesZip() {
+    async _downloadSpeechesArchive(archiveFormat, fallbackFilename) {
       if (!this.ticketId) return false;
       this.speechesErrorMessage = "";
       this.resetArchiveTicketState();
@@ -360,7 +360,7 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
       try {
         // 1. Request archive ticket
         const prepareResponse = await api.post(
-          `/tools/word_trend_speeches/archive/${encodeURIComponent(this.ticketId)}?archive_format=zip`,
+          `/tools/word_trend_speeches/archive/${encodeURIComponent(this.ticketId)}?archive_format=${encodeURIComponent(archiveFormat)}`,
         );
         const archiveTicketId = prepareResponse.data.archive_ticket_id;
         this.archiveTicketId = archiveTicketId;
@@ -383,7 +383,7 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
         downloadDataStore().setupDownload(
           downloadDataStore().getFilenameFromDisposition(
             downloadResponse.headers,
-            `word_trend_speeches_archive_${this.ticketId}.zip`,
+            fallbackFilename,
           ),
           downloadResponse.data,
         );
@@ -398,9 +398,21 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
             error?.message ||
             "Kunde inte hämta anföranden.";
         }
-        console.error("Error downloading word trend speeches ZIP:", error);
+        console.error(`Error downloading word trend speeches archive (${archiveFormat}):`, error);
         return false;
       }
+    },
+
+    async downloadSpeechesZip() {
+      return this._downloadSpeechesArchive("zip", `word_trend_speeches_archive_${this.ticketId}.zip`);
+    },
+
+    async downloadSpeechesJsonlGz() {
+      return this._downloadSpeechesArchive("jsonl_gz", `word_trend_speeches_archive_${this.ticketId}.jsonl.gz`);
+    },
+
+    async downloadSpeechesCsvGz() {
+      return this._downloadSpeechesArchive("csv_gz", `word_trend_speeches_archive_${this.ticketId}.csv.gz`);
     },
 
     async getWordHits(search) {


### PR DESCRIPTION
Expose the existing archive_format endpoint parameter in the frontend. Refactored downloadSpeechesZip into a shared _downloadSpeechesArchive helper and added downloadSpeechesJsonlGz and downloadSpeechesCsvGz store actions. Added corresponding menu items, download keys, handlers, and i18n keys for both sv and en-US locales.

Closes #196