### PR TITLE
feat(kwic+speeches): enhance archive download experience with new formats and notifications

### DIFF
--- a/src/components/kwicDataTable.vue
+++ b/src/components/kwicDataTable.vue
@@ -31,7 +31,24 @@
                   size="16px"
                   class="q-mr-sm"
                 />
-                {{ $t("downloadCSV") }}
+                {{ $t('downloadCSV') }}
+              </q-item-label>
+            </q-item-section>
+          </q-item>
+          <q-item
+            clickable
+            v-close-popup
+            :disable="isDownloadActive(downloadKeys.jsonlgz)"
+            @click="downloadKWICTableAsJsonlGz"
+          >
+            <q-item-section>
+              <q-item-label class="row items-center no-wrap">
+                <q-spinner-tail
+                  v-if="isDownloadActive(downloadKeys.jsonlgz)"
+                  size="16px"
+                  class="q-mr-sm"
+                />
+                {{ $t('downloadKwicJsonlGzArchive') }}
               </q-item-label>
             </q-item-section>
           </q-item>
@@ -48,7 +65,7 @@
                   size="16px"
                   class="q-mr-sm"
                 />
-                {{ $t("downloadExcel") }}
+                {{ $t('downloadExcel') }}
               </q-item-label>
             </q-item-section>
           </q-item>
@@ -65,27 +82,12 @@
                   size="16px"
                   class="q-mr-sm"
                 />
-                {{ $t("downloadSpeech") }}
+                {{ $t('downloadSpeechTextArchive') }}
               </q-item-label>
             </q-item-section>
           </q-item>
         </q-list>
       </q-btn-dropdown>
-
-      <q-btn
-        v-if="kwicStore.archiveTicketId"
-        flat
-        no-caps
-        dense
-        icon="link"
-        class="q-ml-sm text-grey-7"
-        :label="
-          linkCopied
-            ? $t('downloadRetrievalPage.linkCopied')
-            : $t('downloadRetrievalPage.copyLink')
-        "
-        @click="copyRetrievalLink"
-      />
     </div>
     <q-table
       ref="KWICTable"
@@ -209,7 +211,6 @@ import { computed, ref } from "vue";
 import { metaDataStore } from "src/stores/metaDataStore";
 import { kwicDataStore } from "src/stores/kwicDataStore";
 import { downloadDataStore } from "src/stores/downloadDataStore";
-import { useClipboardCopy } from "src/composables/useClipboardCopy";
 import expandingTableRow from "src/components/expandingTableRow.vue";
 import loadingIcon from "src/components/loadingIcon.vue";
 import noResults from "src/components/noResults.vue";
@@ -217,13 +218,10 @@ import noResults from "src/components/noResults.vue";
 const metaStore = metaDataStore();
 const kwicStore = kwicDataStore();
 const downloadStore = downloadDataStore();
-const { linkCopied, copyToClipboard } = useClipboardCopy();
-
-const copyRetrievalLink = () =>
-  copyToClipboard(window.location.origin + '/download/' + kwicStore.archiveTicketId);
 
 const downloadKeys = {
   csv: "kwic-csv",
+  jsonlgz: "kwic-jsonlgz",
   excel: "kwic-excel",
   speeches: "kwic-speeches",
 };
@@ -267,34 +265,19 @@ const isDownloadActive = (downloadKey) =>
   downloadStore.isDownloadActive(downloadKey);
 
 const downloadKWICTableAsExcel = async () => {
-  await downloadStore.runTrackedDownload(
-    downloadKeys.excel,
-    () => kwicStore.downloadKWICTableExcel(),
-    {
-      getErrorMessage: () => kwicStore.errorMessage,
-    },
-  );
+  await kwicStore.downloadKwicExcel(downloadKeys.excel);
 };
 
 const downloadKWICTableAsCSV = async () => {
-  await downloadStore.runTrackedDownload(
-    downloadKeys.csv,
-    () => kwicStore.downloadKWICTableCSV(),
-    {
-      getErrorMessage: () => kwicStore.errorMessage,
-    },
-  );
+  await kwicStore.downloadKwicCsvGz(downloadKeys.csv);
+};
+
+const downloadKWICTableAsJsonlGz = async () => {
+  await kwicStore.downloadKwicJsonlGz(downloadKeys.jsonlgz);
 };
 
 const downloadKWICAsSpeeches = async () => {
-  if (!kwicStore.ticketId) return;
-  await downloadStore.runTrackedDownload(
-    downloadKeys.speeches,
-    () => downloadStore.downloadSpeechesZipByTicket(kwicStore.ticketId),
-    {
-      getErrorMessage: () => kwicStore.errorMessage,
-    },
-  );
+  await kwicStore.downloadKwicSpeechesZip(downloadKeys.speeches);
 };
 
 const rows = computed(() =>

--- a/src/components/speechesTable.vue
+++ b/src/components/speechesTable.vue
@@ -27,34 +27,34 @@
             <q-item
               clickable
               v-close-popup
-              :disable="isDownloadActive(downloadKeys.csv)"
-              @click="downloadCsvArchive"
+              :disable="isDownloadActive(downloadKeys.csvgz)"
+              @click="downloadCsvGzArchive"
             >
               <q-item-section>
                 <q-item-label class="row items-center no-wrap">
                   <q-spinner-tail
-                    v-if="isDownloadActive(downloadKeys.csv)"
+                    v-if="isDownloadActive(downloadKeys.csvgz)"
                     size="16px"
                     class="q-mr-sm"
                   />
-                  {{ $t("downloadSpeechCsvArchive") }}
+                  {{ $t("downloadSpeechCsvGzArchive") }}
                 </q-item-label>
               </q-item-section>
             </q-item>
             <q-item
               clickable
               v-close-popup
-              :disable="isDownloadActive(downloadKeys.json)"
-              @click="downloadJsonArchive"
+              :disable="isDownloadActive(downloadKeys.jsonlgz)"
+              @click="downloadJsonlGzArchive"
             >
               <q-item-section>
                 <q-item-label class="row items-center no-wrap">
                   <q-spinner-tail
-                    v-if="isDownloadActive(downloadKeys.json)"
+                    v-if="isDownloadActive(downloadKeys.jsonlgz)"
                     size="16px"
                     class="q-mr-sm"
                   />
-                  {{ $t("downloadSpeechJsonArchive") }}
+                  {{ $t("downloadSpeechJsonlGzArchive") }}
                 </q-item-label>
               </q-item-section>
             </q-item>
@@ -62,7 +62,7 @@
               clickable
               v-close-popup
               :disable="isDownloadActive(downloadKeys.zip)"
-              @click="downloadSpeechTextArchive"
+              @click="downloadZipArchive"
             >
               <q-item-section>
                 <q-item-label class="row items-center no-wrap">
@@ -77,20 +77,6 @@
             </q-item>
           </q-list>
         </q-btn-dropdown>
-        <q-btn
-          v-if="downloadStore.archiveTicketId"
-          flat
-          no-caps
-          dense
-          icon="link"
-          class="q-ml-sm text-grey-7"
-          :label="
-            linkCopied
-              ? $t('downloadRetrievalPage.linkCopied')
-              : $t('downloadRetrievalPage.copyLink')
-          "
-          @click="copyRetrievalLink"
-        />
       </div>
 
       <q-table
@@ -187,9 +173,6 @@
 
 <script setup>
 import { computed, ref } from "vue";
-import { api } from "boot/axios";
-import { useClipboardCopy } from "src/composables/useClipboardCopy.js";
-import i18n from "src/i18n/sv/index.js";
 import { metaDataStore } from "src/stores/metaDataStore.js";
 import { speechesDataStore } from "src/stores/speechesDataStore";
 import { downloadDataStore } from "src/stores/downloadDataStore";
@@ -202,15 +185,12 @@ const speechesStore = speechesDataStore();
 const downloadStore = downloadDataStore();
 
 const downloadKeys = {
-  csv: "speeches-archive-csv",
-  json: "speeches-archive-json",
+  csvgz: "speeches-archive-csvgz",
+  jsonlgz: "speeches-archive-jsonlgz",
   zip: "speeches-archive-zip",
 };
 
 const SpeechTable = ref(null);
-const { linkCopied, copyToClipboard } = useClipboardCopy();
-const copyRetrievalLink = () =>
-  copyToClipboard(window.location.origin + '/download/' + downloadStore.archiveTicketId);
 
 const pagination = computed({
   get: () => speechesStore.pagination,
@@ -246,90 +226,16 @@ const onRequest = async ({ pagination }) => {
 const isDownloadActive = (downloadKey) =>
   downloadStore.isDownloadActive(downloadKey);
 
-const downloadArchive = async (downloadKey, format) => {
-  if (!speechesStore.ticketId) return;
-
-  await downloadStore.runTrackedDownload(
-    downloadKey,
-    async () => {
-      speechesStore.errorMessage = "";
-
-      try {
-        const response = await api.get(
-          `/tools/speeches/download/${speechesStore.ticketId}`,
-          { params: { format }, responseType: "blob" },
-        );
-        downloadStore.setupDownload(
-          downloadStore.getFilenameFromDisposition(
-            response.headers,
-            `speeches_${speechesStore.ticketId}.zip`,
-          ),
-          response.data,
-        );
-        return true;
-      } catch (error) {
-        if (error.response?.status === 404) {
-          speechesStore.errorMessage = i18n.accessibility.ticketExpired;
-          speechesStore.resetTicketState();
-        } else {
-          speechesStore.errorMessage = downloadStore.getDownloadErrorMessage(
-            error,
-            "Kunde inte hämta anföranden.",
-          );
-        }
-        console.error(`Error downloading speeches ${format} archive:`, error);
-        return false;
-      }
-    },
-    {
-      getErrorMessage: () => speechesStore.errorMessage,
-    },
-  );
+const downloadCsvGzArchive = async () => {
+  await speechesStore.downloadSpeechesCsvGz(downloadKeys.csvgz);
 };
 
-const downloadCsvArchive = async () => {
-  await downloadArchive(downloadKeys.csv, "csv");
+const downloadJsonlGzArchive = async () => {
+  await speechesStore.downloadSpeechesJsonlGz(downloadKeys.jsonlgz);
 };
 
-const downloadJsonArchive = async () => {
-  await downloadArchive(downloadKeys.json, "json");
-};
-
-const downloadSpeechTextArchive = async () => {
-  if (!speechesStore.ticketId) return;
-  await downloadStore.runTrackedDownload(
-    downloadKeys.zip,
-    async () => {
-      speechesStore.errorMessage = "";
-      try {
-        const result = await downloadStore.downloadSpeechesZipByTicket(
-          speechesStore.ticketId,
-        );
-        if (!result) {
-          speechesStore.errorMessage = downloadStore.getDownloadErrorMessage(
-            null,
-            "Kunde inte hämta anföranden.",
-          );
-        }
-        return result;
-      } catch (error) {
-        if (error.response?.status === 404) {
-          speechesStore.errorMessage = i18n.accessibility.ticketExpired;
-          speechesStore.resetTicketState();
-        } else {
-          speechesStore.errorMessage = downloadStore.getDownloadErrorMessage(
-            error,
-            "Kunde inte hämta anföranden.",
-          );
-        }
-        console.error("Error downloading speech text archive:", error);
-        return false;
-      }
-    },
-    {
-      getErrorMessage: () => speechesStore.errorMessage,
-    },
-  );
+const downloadZipArchive = async () => {
+  await speechesStore.downloadSpeechesZip(downloadKeys.zip);
 };
 
 const rows = computed(() =>

--- a/src/i18n/en-US/index.js
+++ b/src/i18n/en-US/index.js
@@ -10,6 +10,7 @@ export default {
   downloadSpeechTextArchive: "Download speeches (.zip)",
   downloadSpeechJsonlGzArchive: "Download speeches (.jsonl.gz)",
   downloadSpeechCsvGzArchive: "Download speeches (.csv.gz)",
+  downloadKwicJsonlGzArchive: "Download KWIC (.jsonl.gz)",
   downloadSpeech: "Download speeches",
   downloadFeedback: {
     preparing: "Preparing download...",

--- a/src/i18n/sv/index.js
+++ b/src/i18n/sv/index.js
@@ -187,6 +187,7 @@ export default {
   downloadSpeechTextArchive: "Ladda ner tal (.zip)",
   downloadSpeechJsonlGzArchive: "Ladda ner tal (.jsonl.gz)",
   downloadSpeechCsvGzArchive: "Ladda ner tal (.csv.gz)",
+  downloadKwicJsonlGzArchive: "Ladda ner KWIC (.jsonl.gz)",
   downloadFeedback: {
     preparing: "Förbereder nedladdning...",
     archiveBuilding: "Arkivet byggs…",

--- a/src/stores/kwicDataStore.js
+++ b/src/stores/kwicDataStore.js
@@ -1,6 +1,7 @@
 import { defineStore } from "pinia";
 import { api } from "boot/axios";
 import axios from "axios";
+import { Notify, copyToClipboard } from "quasar";
 import { metaDataStore } from "./metaDataStore";
 import { downloadDataStore } from "./downloadDataStore";
 import i18n from "src/i18n/sv/index.js";
@@ -52,6 +53,7 @@ export const kwicDataStore = defineStore("kwicData", {
     errorMessage: "",
     hasSubmittedQuery: false,
     archiveTicketId: null,
+    archiveTicketStatus: null,
     archiveRetrievalUrl: null,
     isLoading: false,
     isPageLoading: false,
@@ -87,6 +89,12 @@ export const kwicDataStore = defineStore("kwicData", {
       return search;
     },
 
+    resetArchiveTicketState() {
+      this.archiveTicketId = null;
+      this.archiveTicketStatus = null;
+      this.archiveRetrievalUrl = null;
+    },
+
     resetTicketState() {
       this.kwicData = [];
       this.ticketId = null;
@@ -94,6 +102,7 @@ export const kwicDataStore = defineStore("kwicData", {
       this.totalPages = 0;
       this.expiresAt = null;
       this.archiveTicketId = null;
+      this.archiveTicketStatus = null;
       this.archiveRetrievalUrl = null;
       this.pagination = {
         ...this.pagination,
@@ -332,42 +341,108 @@ export const kwicDataStore = defineStore("kwicData", {
       }
     },
 
-    async downloadKwicArchive(format = "jsonl_gz") {
-      if (!this.ticketId) {
-        this.archiveTicketId = null;
-        this.archiveRetrievalUrl = null;
-        this.errorMessage = i18n.accessibility.ticketExpired;
-        return false;
-      }
+    async _downloadKwicArchive(archiveFormat, fallbackFilename, downloadKey) {
+      if (!this.ticketId) return false;
+      if (downloadKey && downloadDataStore().isDownloadActive(downloadKey)) return false;
+
       this.errorMessage = "";
-      this.archiveTicketId = null;
-      this.archiveRetrievalUrl = null;
+      this.resetArchiveTicketState();
+      downloadDataStore().setDownloadActive(downloadKey, true);
+
+      let dismissLinkNotify = null;
+      let abortedByUser = false;
 
       try {
-        // 1. Request archive ticket
+        // 1. Request archive ticket (~200ms round-trip)
         const prepareResponse = await api.post(
-          `/tools/kwic/archive/${encodeURIComponent(this.ticketId)}?archive_format=${encodeURIComponent(format)}`,
+          `/tools/kwic/archive/${encodeURIComponent(this.ticketId)}?archive_format=${encodeURIComponent(archiveFormat)}`,
         );
         const archiveTicketId = prepareResponse.data.archive_ticket_id;
         this.archiveTicketId = archiveTicketId;
+        this.archiveTicketStatus = "pending";
         this.archiveRetrievalUrl = prepareResponse.data.retrieval_url || null;
 
-        // 2. Poll until ready via generic downloads endpoint
-        await pollArchiveTicket(api, {
-          statusUrl: `/downloads/${archiveTicketId}`,
+        // 2. Immediately show a persistent notification with the retrieval link
+        const retrievalUrl = window.location.origin + "/download/" + archiveTicketId;
+        const buildingHint =
+          i18n.downloadFeedback?.archiveBuildingHint ||
+          "Behåll denna ruta öppen om du vill vänta, eller kopiera länken och stäng för att hämta senare.";
+        dismissLinkNotify = Notify.create({
+          message:
+            (i18n.downloadFeedback?.archiveBuilding || "Arkivet byggs…") + " " + buildingHint,
+          color: "blue-8",
+          icon: "hourglass_top",
+          timeout: 0,
+          position: "top",
+          multiLine: true,
+          actions: [
+            {
+              label: i18n.downloadRetrievalPage?.copyLink || "Kopiera hämtningslänk",
+              color: "yellow",
+              handler: () => {
+                const prevDismiss = dismissLinkNotify;
+                copyToClipboard(retrievalUrl);
+                const copiedHint =
+                  i18n.downloadFeedback?.archiveLinkCopiedClose ||
+                  "Länk kopierad — stäng för att hämta senare, eller vänta här.";
+                dismissLinkNotify = Notify.create({
+                  message: copiedHint,
+                  color: "blue-8",
+                  icon: "check",
+                  timeout: 0,
+                  position: "top",
+                  multiLine: true,
+                  actions: [
+                    {
+                      icon: "close",
+                      color: "white",
+                      round: true,
+                      handler: () => {
+                        abortedByUser = true;
+                        if (typeof dismissLinkNotify === "function") {
+                          dismissLinkNotify();
+                          dismissLinkNotify = null;
+                        }
+                      },
+                    },
+                  ],
+                });
+                if (typeof prevDismiss === "function") prevDismiss();
+              },
+            },
+          ],
         });
 
-        // 3. Download the artifact
+        // 3. Poll until ready via generic downloads endpoint
+        await pollArchiveTicket(api, {
+          statusUrl: `/downloads/${archiveTicketId}`,
+          onStatus: (status) => {
+            this.archiveTicketStatus = status;
+          },
+        });
+
+        // 4. Download the artifact — skip if user said "I'll fetch it later"
+        if (abortedByUser) {
+          Notify.create({
+            message:
+              i18n.downloadFeedback?.archiveAborted ||
+              "Nedladdning avbruten — använd länken för att hämta filen när den är klar.",
+            color: "info",
+            icon: "link",
+            timeout: 6000,
+            position: "top",
+          });
+          return true;
+        }
+
         const downloadResponse = await api.get(
           `/downloads/${archiveTicketId}/download`,
           { responseType: "blob" },
         );
-        const archiveExtensions = { csv_gz: "csv.gz", jsonl_gz: "jsonl.gz" };
-        const fileExtension = archiveExtensions[format] ?? format;
         downloadDataStore().setupDownload(
           downloadDataStore().getFilenameFromDisposition(
             downloadResponse.headers,
-            `kwic_archive_${this.ticketId}.${fileExtension}`,
+            fallbackFilename,
           ),
           downloadResponse.data,
         );
@@ -379,17 +454,179 @@ export const kwicDataStore = defineStore("kwicData", {
         } else {
           this.errorMessage = this.getErrorMessage(error);
         }
-        console.error("Error downloading KWIC archive:", error);
+        Notify.create({
+          type: "negative",
+          message: this.errorMessage,
+          timeout: 4000,
+          position: "top",
+        });
+        console.error(`Error downloading KWIC archive (${archiveFormat}):`, error);
         return false;
+      } finally {
+        if (typeof dismissLinkNotify === "function") {
+          dismissLinkNotify();
+          dismissLinkNotify = null;
+        }
+        downloadDataStore().setDownloadActive(downloadKey, false);
       }
     },
 
-    async downloadKWICTableExcel() {
-      return this.downloadKwicArchive("xlsx");
+    async _downloadKwicSpeechesArchive(archiveFormat, fallbackFilename, downloadKey) {
+      if (!this.ticketId) return false;
+      if (downloadKey && downloadDataStore().isDownloadActive(downloadKey)) return false;
+
+      this.errorMessage = "";
+      this.resetArchiveTicketState();
+      downloadDataStore().setDownloadActive(downloadKey, true);
+
+      let dismissLinkNotify = null;
+      let abortedByUser = false;
+
+      try {
+        const prepareResponse = await api.post(
+          `/tools/speeches/archive/${encodeURIComponent(this.ticketId)}?archive_format=${encodeURIComponent(archiveFormat)}`,
+        );
+        const archiveTicketId = prepareResponse.data.archive_ticket_id;
+        this.archiveTicketId = archiveTicketId;
+        this.archiveTicketStatus = "pending";
+        this.archiveRetrievalUrl = prepareResponse.data.retrieval_url || null;
+
+        const retrievalUrl = window.location.origin + "/download/" + archiveTicketId;
+        const buildingHint =
+          i18n.downloadFeedback?.archiveBuildingHint ||
+          "Behåll denna ruta öppen om du vill vänta, eller kopiera länken och stäng för att hämta senare.";
+        dismissLinkNotify = Notify.create({
+          message:
+            (i18n.downloadFeedback?.archiveBuilding || "Arkivet byggs…") + " " + buildingHint,
+          color: "blue-8",
+          icon: "hourglass_top",
+          timeout: 0,
+          position: "top",
+          multiLine: true,
+          actions: [
+            {
+              label: i18n.downloadRetrievalPage?.copyLink || "Kopiera hämtningslänk",
+              color: "yellow",
+              handler: () => {
+                const prevDismiss = dismissLinkNotify;
+                copyToClipboard(retrievalUrl);
+                const copiedHint =
+                  i18n.downloadFeedback?.archiveLinkCopiedClose ||
+                  "Länk kopierad — stäng för att hämta senare, eller vänta här.";
+                dismissLinkNotify = Notify.create({
+                  message: copiedHint,
+                  color: "blue-8",
+                  icon: "check",
+                  timeout: 0,
+                  position: "top",
+                  multiLine: true,
+                  actions: [
+                    {
+                      icon: "close",
+                      color: "white",
+                      round: true,
+                      handler: () => {
+                        abortedByUser = true;
+                        if (typeof dismissLinkNotify === "function") {
+                          dismissLinkNotify();
+                          dismissLinkNotify = null;
+                        }
+                      },
+                    },
+                  ],
+                });
+                if (typeof prevDismiss === "function") prevDismiss();
+              },
+            },
+          ],
+        });
+
+        await pollArchiveTicket(api, {
+          statusUrl: `/tools/speeches/archive/status/${archiveTicketId}`,
+          onStatus: (status) => {
+            this.archiveTicketStatus = status;
+          },
+        });
+
+        if (abortedByUser) {
+          Notify.create({
+            message:
+              i18n.downloadFeedback?.archiveAborted ||
+              "Nedladdning avbruten — använd länken för att hämta filen när den är klar.",
+            color: "info",
+            icon: "link",
+            timeout: 6000,
+            position: "top",
+          });
+          return true;
+        }
+
+        const downloadResponse = await api.get(
+          `/tools/speeches/archive/download/${archiveTicketId}`,
+          { responseType: "blob" },
+        );
+        downloadDataStore().setupDownload(
+          downloadDataStore().getFilenameFromDisposition(
+            downloadResponse.headers,
+            fallbackFilename,
+          ),
+          downloadResponse.data,
+        );
+        return true;
+      } catch (error) {
+        if (error.response?.status === 404) {
+          this.errorMessage = i18n.accessibility.ticketExpired;
+          this.resetTicketState();
+        } else {
+          this.errorMessage = this.getErrorMessage(error);
+        }
+        Notify.create({
+          type: "negative",
+          message: this.errorMessage,
+          timeout: 4000,
+          position: "top",
+        });
+        console.error(`Error downloading KWIC speeches archive (${archiveFormat}):`, error);
+        return false;
+      } finally {
+        if (typeof dismissLinkNotify === "function") {
+          dismissLinkNotify();
+          dismissLinkNotify = null;
+        }
+        downloadDataStore().setDownloadActive(downloadKey, false);
+      }
     },
 
-    async downloadKWICTableCSV() {
-      return this.downloadKwicArchive("csv_gz");
+    async downloadKwicExcel(downloadKey) {
+      return this._downloadKwicArchive(
+        "xlsx",
+        `kwic_archive_${this.ticketId}.xlsx`,
+        downloadKey,
+      );
+    },
+
+    async downloadKwicCsvGz(downloadKey) {
+      return this._downloadKwicArchive(
+        "csv_gz",
+        `kwic_archive_${this.ticketId}.csv.gz`,
+        downloadKey,
+      );
+    },
+
+    async downloadKwicJsonlGz(downloadKey) {
+      return this._downloadKwicArchive(
+        "jsonl_gz",
+        `kwic_archive_${this.ticketId}.jsonl.gz`,
+        downloadKey,
+      );
+    },
+
+    async downloadKwicSpeechesZip(downloadKey) {
+      return this._downloadKwicSpeechesArchive(
+        "zip",
+        `kwic_speeches_${this.ticketId}.zip`,
+        downloadKey,
+      );
     },
   },
 });

--- a/src/stores/speechesDataStore.js
+++ b/src/stores/speechesDataStore.js
@@ -1,10 +1,13 @@
 import { defineStore } from "pinia";
 import { api } from "boot/axios";
 import { metaDataStore } from "./metaDataStore";
+import { downloadDataStore } from "./downloadDataStore";
 import axios from "axios";
+import { Notify, copyToClipboard } from "quasar";
 import i18n from "src/i18n/sv/index.js";
 import {
   getTicketPollDelayMs,
+  pollArchiveTicket,
   TICKET_POLL_MAX_ATTEMPTS,
 } from "./ticketPolling";
 
@@ -30,6 +33,9 @@ export const speechesDataStore = defineStore("speechesData", {
     isPageLoading: false,
     requestSequence: 0,
     pageRequestSequence: 0,
+    archiveTicketId: null,
+    archiveTicketStatus: null,
+    archiveRetrievalUrl: null,
     pagination: {
       sortBy: "year",
       descending: true,
@@ -61,6 +67,12 @@ export const speechesDataStore = defineStore("speechesData", {
       } catch (error) {
         console.error("Error fetching data:", error);
       }
+    },
+
+    resetArchiveTicketState() {
+      this.archiveTicketId = null;
+      this.archiveTicketStatus = null;
+      this.archiveRetrievalUrl = null;
     },
 
     resetTicketState() {
@@ -207,6 +219,158 @@ export const speechesDataStore = defineStore("speechesData", {
           this.isLoading = false;
         }
       }
+    },
+    async _downloadSpeechesArchive(archiveFormat, fallbackFilename, downloadKey) {
+      if (!this.ticketId) return false;
+      if (downloadKey && downloadDataStore().isDownloadActive(downloadKey)) return false;
+
+      this.errorMessage = "";
+      this.resetArchiveTicketState();
+      downloadDataStore().setDownloadActive(downloadKey, true);
+
+      let dismissLinkNotify = null;
+      let abortedByUser = false;
+
+      try {
+        const prepareResponse = await api.post(
+          `/tools/speeches/archive/${encodeURIComponent(this.ticketId)}?archive_format=${encodeURIComponent(archiveFormat)}`,
+        );
+        const archiveTicketId = prepareResponse.data.archive_ticket_id;
+        this.archiveTicketId = archiveTicketId;
+        this.archiveTicketStatus = "pending";
+        this.archiveRetrievalUrl = prepareResponse.data.retrieval_url || null;
+
+        const retrievalUrl = window.location.origin + "/download/" + archiveTicketId;
+        const buildingHint =
+          i18n.downloadFeedback?.archiveBuildingHint ||
+          "Behåll denna ruta öppen om du vill vänta, eller kopiera länken och stäng för att hämta senare.";
+        dismissLinkNotify = Notify.create({
+          message:
+            (i18n.downloadFeedback?.archiveBuilding || "Arkivet byggs…") + " " + buildingHint,
+          color: "blue-8",
+          icon: "hourglass_top",
+          timeout: 0,
+          position: "top",
+          multiLine: true,
+          actions: [
+            {
+              label: i18n.downloadRetrievalPage?.copyLink || "Kopiera hämtningslänk",
+              color: "yellow",
+              handler: () => {
+                const prevDismiss = dismissLinkNotify;
+                copyToClipboard(retrievalUrl);
+                const copiedHint =
+                  i18n.downloadFeedback?.archiveLinkCopiedClose ||
+                  "Länk kopierad — stäng för att hämta senare, eller vänta här.";
+                dismissLinkNotify = Notify.create({
+                  message: copiedHint,
+                  color: "blue-8",
+                  icon: "check",
+                  timeout: 0,
+                  position: "top",
+                  multiLine: true,
+                  actions: [
+                    {
+                      icon: "close",
+                      color: "white",
+                      round: true,
+                      handler: () => {
+                        abortedByUser = true;
+                        if (typeof dismissLinkNotify === "function") {
+                          dismissLinkNotify();
+                          dismissLinkNotify = null;
+                        }
+                      },
+                    },
+                  ],
+                });
+                if (typeof prevDismiss === "function") prevDismiss();
+              },
+            },
+          ],
+        });
+
+        await pollArchiveTicket(api, {
+          statusUrl: `/tools/speeches/archive/status/${archiveTicketId}`,
+          onStatus: (status) => {
+            this.archiveTicketStatus = status;
+          },
+        });
+
+        if (abortedByUser) {
+          Notify.create({
+            message:
+              i18n.downloadFeedback?.archiveAborted ||
+              "Nedladdning avbruten — använd länken för att hämta filen när den är klar.",
+            color: "info",
+            icon: "link",
+            timeout: 6000,
+            position: "top",
+          });
+          return true;
+        }
+
+        const downloadResponse = await api.get(
+          `/tools/speeches/archive/download/${archiveTicketId}`,
+          { responseType: "blob" },
+        );
+        downloadDataStore().setupDownload(
+          downloadDataStore().getFilenameFromDisposition(
+            downloadResponse.headers,
+            fallbackFilename,
+          ),
+          downloadResponse.data,
+        );
+        return true;
+      } catch (error) {
+        if (error.response?.status === 404) {
+          this.errorMessage = i18n.accessibility.ticketExpired;
+          this.resetTicketState();
+        } else {
+          this.errorMessage =
+            error?.response?.data?.detail ||
+            error?.message ||
+            "Kunde inte hämta anföranden.";
+        }
+        Notify.create({
+          type: "negative",
+          message: this.errorMessage,
+          timeout: 4000,
+          position: "top",
+        });
+        console.error(`Error downloading speeches archive (${archiveFormat}):`, error);
+        return false;
+      } finally {
+        if (typeof dismissLinkNotify === "function") {
+          dismissLinkNotify();
+          dismissLinkNotify = null;
+        }
+        downloadDataStore().setDownloadActive(downloadKey, false);
+      }
+    },
+
+    async downloadSpeechesZip(downloadKey) {
+      return this._downloadSpeechesArchive(
+        "zip",
+        `speeches_${this.ticketId}.zip`,
+        downloadKey,
+      );
+    },
+
+    async downloadSpeechesCsvGz(downloadKey) {
+      return this._downloadSpeechesArchive(
+        "csv_gz",
+        `speeches_${this.ticketId}.csv.gz`,
+        downloadKey,
+      );
+    },
+
+    async downloadSpeechesJsonlGz(downloadKey) {
+      return this._downloadSpeechesArchive(
+        "jsonl_gz",
+        `speeches_${this.ticketId}.jsonl.gz`,
+        downloadKey,
+      );
     },
   },
 });

--- a/src/stores/wordTrendsDataStore.js
+++ b/src/stores/wordTrendsDataStore.js
@@ -379,7 +379,7 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
         const buildingHint = i18n.downloadFeedback?.archiveBuildingHint || "Behåll denna ruta öppen om du vill vänta, eller kopiera länken och stäng för att hämta senare.";
         dismissLinkNotify = Notify.create({
           message: (i18n.downloadFeedback?.archiveBuilding || "Arkivet byggs…") + " " + buildingHint,
-          color: "primary",
+          color: "blue-8",
           icon: "hourglass_top",
           timeout: 0,
           position: "top",
@@ -395,7 +395,7 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
                 const copiedHint = i18n.downloadFeedback?.archiveLinkCopiedClose || "Länk kopierad — stäng för att hämta senare, eller vänta här.";
                 dismissLinkNotify = Notify.create({
                   message: copiedHint,
-                  color: "primary",
+                  color: "blue-8",
                   icon: "check",
                   timeout: 0,
                   position: "top",

--- a/src/stores/wordTrendsDataStore.js
+++ b/src/stores/wordTrendsDataStore.js
@@ -353,9 +353,14 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
       }
     },
 
-    async _downloadSpeechesArchive(archiveFormat, fallbackFilename, downloadKey) {
+    async _downloadSpeechesArchive(
+      archiveFormat,
+      fallbackFilename,
+      downloadKey,
+    ) {
       if (!this.ticketId) return false;
-      if (downloadKey && downloadDataStore().isDownloadActive(downloadKey)) return false;
+      if (downloadKey && downloadDataStore().isDownloadActive(downloadKey))
+        return false;
 
       this.speechesErrorMessage = "";
       this.resetArchiveTicketState();
@@ -375,10 +380,16 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
         this.archiveRetrievalUrl = prepareResponse.data.retrieval_url || null;
 
         // 2. Immediately show a persistent notification with the retrieval link
-        const retrievalUrl = window.location.origin + "/download/" + archiveTicketId;
-        const buildingHint = i18n.downloadFeedback?.archiveBuildingHint || "Behåll denna ruta öppen om du vill vänta, eller kopiera länken och stäng för att hämta senare.";
+        const retrievalUrl =
+          window.location.origin + "/download/" + archiveTicketId;
+        const buildingHint =
+          i18n.downloadFeedback?.archiveBuildingHint ||
+          "Behåll denna ruta öppen om du vill vänta, eller kopiera länken och stäng för att hämta senare.";
         dismissLinkNotify = Notify.create({
-          message: (i18n.downloadFeedback?.archiveBuilding || "Arkivet byggs…") + " " + buildingHint,
+          message:
+            (i18n.downloadFeedback?.archiveBuilding || "Arkivet byggs…") +
+            " " +
+            buildingHint,
           color: "blue-8",
           icon: "hourglass_top",
           timeout: 0,
@@ -386,13 +397,16 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
           multiLine: true,
           actions: [
             {
-              label: i18n.downloadRetrievalPage?.copyLink || "Kopiera hämtningslänk",
+              label:
+                i18n.downloadRetrievalPage?.copyLink || "Kopiera hämtningslänk",
               color: "yellow",
               handler: () => {
                 const prevDismiss = dismissLinkNotify;
                 copyToClipboard(retrievalUrl);
                 // Replace notification: now shows copied message + X to abort
-                const copiedHint = i18n.downloadFeedback?.archiveLinkCopiedClose || "Länk kopierad — stäng för att hämta senare, eller vänta här.";
+                const copiedHint =
+                  i18n.downloadFeedback?.archiveLinkCopiedClose ||
+                  "Länk kopierad — stäng för att hämta senare, eller vänta här.";
                 dismissLinkNotify = Notify.create({
                   message: copiedHint,
                   color: "blue-8",
@@ -432,7 +446,9 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
         // 4. Download the artifact — skip if user said "I'll fetch it later"
         if (abortedByUser) {
           Notify.create({
-            message: i18n.downloadFeedback?.archiveAborted || "Nedladdning avbruten — använd länken för att hämta filen när den är klar.",
+            message:
+              i18n.downloadFeedback?.archiveAborted ||
+              "Nedladdning avbruten — använd länken för att hämta filen när den är klar.",
             color: "info",
             icon: "link",
             timeout: 6000,
@@ -469,7 +485,10 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
           timeout: 4000,
           position: "top",
         });
-        console.error(`Error downloading word trend speeches archive (${archiveFormat}):`, error);
+        console.error(
+          `Error downloading word trend speeches archive (${archiveFormat}):`,
+          error,
+        );
         return false;
       } finally {
         if (typeof dismissLinkNotify === "function") {
@@ -481,15 +500,27 @@ export const wordTrendsDataStore = defineStore("wordTrendsData", {
     },
 
     async downloadSpeechesZip(downloadKey) {
-      return this._downloadSpeechesArchive("zip", `word_trend_speeches_archive_${this.ticketId}.zip`, downloadKey);
+      return this._downloadSpeechesArchive(
+        "zip",
+        `word_trend_speeches_archive_${this.ticketId}.zip`,
+        downloadKey,
+      );
     },
 
     async downloadSpeechesJsonlGz(downloadKey) {
-      return this._downloadSpeechesArchive("jsonl_gz", `word_trend_speeches_archive_${this.ticketId}.jsonl.gz`, downloadKey);
+      return this._downloadSpeechesArchive(
+        "jsonl_gz",
+        `word_trend_speeches_archive_${this.ticketId}.jsonl.gz`,
+        downloadKey,
+      );
     },
 
     async downloadSpeechesCsvGz(downloadKey) {
-      return this._downloadSpeechesArchive("csv_gz", `word_trend_speeches_archive_${this.ticketId}.csv.gz`, downloadKey);
+      return this._downloadSpeechesArchive(
+        "csv_gz",
+        `word_trend_speeches_archive_${this.ticketId}.csv.gz`,
+        downloadKey,
+      );
     },
 
     async getWordHits(search) {


### PR DESCRIPTION
Implemented a persistent notification system for KWIC and Anföranden archive downloads, providing users with immediate feedback and retrieval links. Added new download options for KWIC (CSV.gz, JSONL.gz) and updated Anföranden formats. Removed outdated copy-link buttons, streamlining the user interface.

Fixes #200