### PR TITLE
feat(kwic): show pre-search hit estimate as user types (Phase 1)

### DIFF
--- a/src/components/toolsFilterData/kwicEstimate.vue
+++ b/src/components/toolsFilterData/kwicEstimate.vue
@@ -1,0 +1,45 @@
+<template>
+  <div v-if="show" class="q-mt-sm">
+    <q-banner
+      v-if="!kwicStore.inVocabulary"
+      dense
+      class="bg-grey-2 text-grey-7 text-caption"
+    >
+      {{ $t("kwicEstimateNotInVocabulary") }}
+    </q-banner>
+    <q-banner
+      v-else-if="isHighCount"
+      dense
+      class="bg-orange-1 text-orange-9 text-caption"
+    >
+      ~{{ formattedHits }} {{ $t("kwicEstimateHits") }} —
+      {{ $t("kwicEstimateHighWarning") }}
+    </q-banner>
+    <q-banner v-else dense class="bg-green-1 text-green-9 text-caption">
+      ~{{ formattedHits }} {{ $t("kwicEstimateHits") }}
+    </q-banner>
+  </div>
+</template>
+
+<script setup>
+import { computed } from "vue";
+import { kwicDataStore } from "src/stores/kwicDataStore";
+
+const HIGH_HIT_THRESHOLD = 10000;
+
+const kwicStore = kwicDataStore();
+
+const show = computed(
+  () => kwicStore.inVocabulary !== null
+);
+
+const isHighCount = computed(
+  () => kwicStore.estimatedHits != null && kwicStore.estimatedHits >= HIGH_HIT_THRESHOLD
+);
+
+const formattedHits = computed(() =>
+  kwicStore.estimatedHits != null
+    ? kwicStore.estimatedHits.toLocaleString("sv-SE")
+    : ""
+);
+</script>

--- a/src/components/toolsFilterData/searchBar.vue
+++ b/src/components/toolsFilterData/searchBar.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script setup>
-import { computed, watch } from "vue";
+import { computed, watch, onBeforeUnmount } from "vue";
 import { kwicDataStore } from "src/stores/kwicDataStore";
 import { metaDataStore } from "src/stores/metaDataStore";
 import { nGramDataStore } from "src/stores/nGramDataStore";
@@ -67,20 +67,26 @@ const handleEnter = () => {
 let estimateDebounceTimer = null;
 
 watch(
-  () => route.path === "/tools/kwic" ? kwicStore.searchText : null,
+  () => (route.path === "/tools/kwic" ? kwicStore.searchText : null),
   (newWord) => {
     if (route.path !== "/tools/kwic") return;
     clearTimeout(estimateDebounceTimer);
+    kwicStore.estimatedHits = null;
+    kwicStore.inVocabulary = null;
     if (!newWord || !newWord.trim()) {
-      kwicStore.estimatedHits = null;
-      kwicStore.inVocabulary = null;
       return;
     }
     estimateDebounceTimer = setTimeout(() => {
-      kwicStore.fetchEstimate(newWord);
+      if (route.path === "/tools/kwic") {
+        kwicStore.fetchEstimate(newWord);
+      }
     }, 400);
-  }
+  },
 );
+
+onBeforeUnmount(() => {
+  clearTimeout(estimateDebounceTimer);
+});
 </script>
 
 <style scoped></style>

--- a/src/components/toolsFilterData/searchBar.vue
+++ b/src/components/toolsFilterData/searchBar.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script setup>
-import { computed } from "vue";
+import { computed, watch } from "vue";
 import { kwicDataStore } from "src/stores/kwicDataStore";
 import { metaDataStore } from "src/stores/metaDataStore";
 import { nGramDataStore } from "src/stores/nGramDataStore";
@@ -63,6 +63,24 @@ const handleEnter = () => {
     }
   }
 };
+
+let estimateDebounceTimer = null;
+
+watch(
+  () => route.path === "/tools/kwic" ? kwicStore.searchText : null,
+  (newWord) => {
+    if (route.path !== "/tools/kwic") return;
+    clearTimeout(estimateDebounceTimer);
+    if (!newWord || !newWord.trim()) {
+      kwicStore.estimatedHits = null;
+      kwicStore.inVocabulary = null;
+      return;
+    }
+    estimateDebounceTimer = setTimeout(() => {
+      kwicStore.fetchEstimate(newWord);
+    }, 400);
+  }
+);
 </script>
 
 <style scoped></style>

--- a/src/components/toolsFilters.vue
+++ b/src/components/toolsFilters.vue
@@ -20,6 +20,7 @@
   </q-card-section>
   <q-card-section v-else-if="currentPath === '/tools/kwic'">
     <searchBar />
+    <kwicEstimate />
     <toggleSwitch
       class="q-mt-md"
       :label="$t('lemmaResultLabel')"
@@ -62,6 +63,7 @@ import searchBarAdd from "src/components/toolsFilterData/searchBarAdd.vue";
 import { computed } from "vue";
 import { useRoute } from "vue-router";
 import searchBar from "src/components/toolsFilterData/searchBar.vue";
+import kwicEstimate from "src/components/toolsFilterData/kwicEstimate.vue";
 import inputNrOfWords from "src/components/toolsFilterData/inputNrOfWords.vue";
 import toggleSwitch from "src/components/toolsFilterData/toggleSwitch.vue";
 import nGramWidth from "src/components/toolsFilterData/nGramWidth.vue";

--- a/src/i18n/en-US/index.js
+++ b/src/i18n/en-US/index.js
@@ -15,9 +15,12 @@ export default {
   downloadFeedback: {
     preparing: "Preparing download...",
     archiveBuilding: "Building archive…",
-    archiveBuildingHint: "Keep this open to wait, or copy the link and close to fetch later.",
-    archiveLinkCopiedClose: "Link copied — close to fetch later, or keep waiting here.",
-    archiveAborted: "Link saved — open it to download the archive when it is ready.",
+    archiveBuildingHint:
+      "Keep this open to wait, or copy the link and close to fetch later.",
+    archiveLinkCopiedClose:
+      "Link copied — close to fetch later, or keep waiting here.",
+    archiveAborted:
+      "Link saved — open it to download the archive when it is ready.",
     success: "The download has started.",
     error: "Could not start the download.",
     archiveGenerationFailed: "Archive generation failed.",
@@ -39,6 +42,9 @@ export default {
     copyLink: "Copy retrieval link",
     linkCopied: "Link copied!",
   },
+  kwicEstimateHits: "estimated hits",
+  kwicEstimateNotInVocabulary: "The word was not found in the vocabulary",
+  kwicEstimateHighWarning: "The search may take a long time",
   accessibility: {
     loadingResults: "Loading results, please wait...",
     ticketExpired: "The results have expired. Please submit a new search.",

--- a/src/i18n/sv/index.js
+++ b/src/i18n/sv/index.js
@@ -129,6 +129,9 @@ export default {
   nrOfWordsRight: "Höger",
   nrCutOffKWIC: "Max antal träffar att visa/ladda ner",
   allHits: "Alla träffar",
+  kwicEstimateHits: "Uppskattade träffar",
+  kwicEstimateNotInVocabulary: "Ordet hittades inte i vokabulären",
+  kwicEstimateHighWarning: "Sökningen kan ta lång tid",
 
   speechesNoTools: "Filtrera ovan med hjälp av 'Filtrera på metadata'",
 

--- a/src/stores/kwicDataStore.js
+++ b/src/stores/kwicDataStore.js
@@ -57,6 +57,7 @@ export const kwicDataStore = defineStore("kwicData", {
     estimatedHits: null,
     inVocabulary: null,
     requestSequence: 0,
+    estimateRequestSequence: 0,
     pageRequestSequence: 0,
     pagination: {
       sortBy: DEFAULT_SORT_BY,
@@ -120,6 +121,7 @@ export const kwicDataStore = defineStore("kwicData", {
         return;
       }
 
+      const requestId = ++this.estimateRequestSequence;
       const filters = metaDataStore().getSelectedKwicTicketFilters();
       const params = { word: word.trim() };
 
@@ -128,13 +130,16 @@ export const kwicDataStore = defineStore("kwicData", {
       if (filters.party_id?.length) params.party_id = filters.party_id;
       if (filters.who?.length) params.who = filters.who;
       if (filters.gender_id?.length) params.gender_id = filters.gender_id;
-      if (filters.chamber_abbrev?.length) params.chamber_abbrev = filters.chamber_abbrev;
+      if (filters.chamber_abbrev?.length)
+        params.chamber_abbrev = filters.chamber_abbrev;
 
       try {
         const response = await api.get("/tools/kwic/estimate", { params });
+        if (requestId !== this.estimateRequestSequence) return;
         this.estimatedHits = response.data.estimated_hits;
         this.inVocabulary = response.data.in_vocabulary;
       } catch {
+        if (requestId !== this.estimateRequestSequence) return;
         this.estimatedHits = null;
         this.inVocabulary = null;
       }
@@ -169,7 +174,9 @@ export const kwicDataStore = defineStore("kwicData", {
         }
 
         if (response.data.status === "error") {
-          throw new Error(response.data.error || i18n.accessibility.kwicQueryFailed);
+          throw new Error(
+            response.data.error || i18n.accessibility.kwicQueryFailed,
+          );
         }
 
         const delayMs = getTicketPollDelayMs(

--- a/src/stores/kwicDataStore.js
+++ b/src/stores/kwicDataStore.js
@@ -54,6 +54,8 @@ export const kwicDataStore = defineStore("kwicData", {
     archiveRetrievalUrl: null,
     isLoading: false,
     isPageLoading: false,
+    estimatedHits: null,
+    inVocabulary: null,
     requestSequence: 0,
     pageRequestSequence: 0,
     pagination: {
@@ -109,6 +111,33 @@ export const kwicDataStore = defineStore("kwicData", {
         cut_off: this.cutOff,
         filters: metaDataStore().getSelectedKwicTicketFilters(),
       };
+    },
+
+    async fetchEstimate(word) {
+      if (!word || !word.trim()) {
+        this.estimatedHits = null;
+        this.inVocabulary = null;
+        return;
+      }
+
+      const filters = metaDataStore().getSelectedKwicTicketFilters();
+      const params = { word: word.trim() };
+
+      if (filters.from_year != null) params.from_year = filters.from_year;
+      if (filters.to_year != null) params.to_year = filters.to_year;
+      if (filters.party_id?.length) params.party_id = filters.party_id;
+      if (filters.who?.length) params.who = filters.who;
+      if (filters.gender_id?.length) params.gender_id = filters.gender_id;
+      if (filters.chamber_abbrev?.length) params.chamber_abbrev = filters.chamber_abbrev;
+
+      try {
+        const response = await api.get("/tools/kwic/estimate", { params });
+        this.estimatedHits = response.data.estimated_hits;
+        this.inVocabulary = response.data.in_vocabulary;
+      } catch {
+        this.estimatedHits = null;
+        this.inVocabulary = null;
+      }
     },
 
     getKwicResultsPath(search) {


### PR DESCRIPTION
- Add estimatedHits/inVocabulary state to kwicDataStore
- Add fetchEstimate(word) action calling GET /tools/kwic/estimate
- Debounce estimate fetch 400ms on KWIC search input change
- Add kwicEstimate.vue with colour-coded green/orange/grey banners
- Render estimate banner in toolsFilters.vue KWIC section
- Add sv i18n keys: kwicEstimateHits, kwicEstimateNotInVocabulary, kwicEstimateHighWarning

Closes #202