### PR TITLE
feat(kwic): consume display cap fields and show banner for large result sets

### DIFF
--- a/src/components/toolsFilterData/inputNrOfWords.vue
+++ b/src/components/toolsFilterData/inputNrOfWords.vue
@@ -43,29 +43,10 @@
       </q-input>
     </div>
   </q-card-section>
-  <q-select
-    v-model="kwicStore.cutOff"
-    :options="cutOffOptions"
-    emit-value
-    map-options
-    outlined
-    :label="$t('nrCutOffKWIC')"
-    class="bg-white q-mt-sm"
-    color="accent"
-  />
 </template>
 
 <script setup>
-import { useI18n } from "vue-i18n";
 import { kwicDataStore } from "src/stores/kwicDataStore.js";
 
-const { t } = useI18n();
 const kwicStore = kwicDataStore();
-
-const cutOffOptions = [
-  { label: "100 000", value: 100000 },
-  { label: "1 000 000", value: 1000000 },
-  { label: "10 000 000", value: 10000000 },
-  { label: t("allHits"), value: null },
-];
 </script>

--- a/src/i18n/en-US/index.js
+++ b/src/i18n/en-US/index.js
@@ -45,6 +45,8 @@ export default {
   kwicEstimateHits: "estimated hits",
   kwicEstimateNotInVocabulary: "The word was not found in the vocabulary",
   kwicEstimateHighWarning: "The search may take a long time",
+  kwicDisplayLimitBanner:
+    "The search has ~{total} hits. The table shows the first {limit}. Download to retrieve all.",
   accessibility: {
     loadingResults: "Loading results, please wait...",
     ticketExpired: "The results have expired. Please submit a new search.",

--- a/src/i18n/sv/index.js
+++ b/src/i18n/sv/index.js
@@ -132,6 +132,8 @@ export default {
   kwicEstimateHits: "Uppskattade träffar",
   kwicEstimateNotInVocabulary: "Ordet hittades inte i vokabulären",
   kwicEstimateHighWarning: "Sökningen kan ta lång tid",
+  kwicDisplayLimitBanner:
+    "Sökningen har ~{total} träffar. Tabellen visar de första {limit}. Ladda ner för att hämta alla.",
 
   speechesNoTools: "Filtrera ovan med hjälp av 'Filtrera på metadata'",
 
@@ -194,9 +196,12 @@ export default {
   downloadFeedback: {
     preparing: "Förbereder nedladdning...",
     archiveBuilding: "Arkivet byggs…",
-    archiveBuildingHint: "Behåll denna ruta öppen om du vill vänta, eller kopiera länken och stäng för att hämta senare.",
-    archiveLinkCopiedClose: "Länk kopierad — stäng för att hämta senare, eller vänta här.",
-    archiveAborted: "Länken är sparad — öppna den för att hämta arkivet när det är klart.",
+    archiveBuildingHint:
+      "Behåll denna ruta öppen om du vill vänta, eller kopiera länken och stäng för att hämta senare.",
+    archiveLinkCopiedClose:
+      "Länk kopierad — stäng för att hämta senare, eller vänta här.",
+    archiveAborted:
+      "Länken är sparad — öppna den för att hämta arkivet när det är klart.",
     success: "Nedladdningen har startat.",
     error: "Kunde inte starta nedladdningen.",
     archiveGenerationFailed: "Arkivgenerering misslyckades.",

--- a/src/i18n/sv/index.js
+++ b/src/i18n/sv/index.js
@@ -127,8 +127,6 @@ export default {
   nrOfWordsSearch: "Sökord",
   nrOfWordsLeft: "Vänster",
   nrOfWordsRight: "Höger",
-  nrCutOffKWIC: "Max antal träffar att visa/ladda ner",
-  allHits: "Alla träffar",
   kwicEstimateHits: "Uppskattade träffar",
   kwicEstimateNotInVocabulary: "Ordet hittades inte i vokabulären",
   kwicEstimateHighWarning: "Sökningen kan ta lång tid",

--- a/src/pages/KWICPage.vue
+++ b/src/pages/KWICPage.vue
@@ -27,8 +27,8 @@
     >
       {{
         $t("kwicDisplayLimitBanner", {
-          total: kwicStore.totalHits.toLocaleString("sv-SE"),
-          limit: kwicStore.displayLimit.toLocaleString("sv-SE"),
+          total: formattedTotalHits,
+          limit: formattedDisplayLimit,
         })
       }}
     </q-banner>
@@ -56,10 +56,19 @@ import loadingIcon from "src/components/loadingIcon.vue";
 import { metaDataStore } from "src/stores/metaDataStore.js";
 import { kwicDataStore } from "src/stores/kwicDataStore";
 import i18n from "src/i18n/sv";
-import { ref, watch, onMounted } from "vue";
+import { ref, watch, onMounted, computed } from "vue";
+import { useI18n } from "vue-i18n";
 
+const { locale } = useI18n();
 const metaStore = metaDataStore();
 const kwicStore = kwicDataStore();
+
+const formattedTotalHits = computed(() =>
+  kwicStore.totalHits != null ? kwicStore.totalHits.toLocaleString(locale.value) : "",
+);
+const formattedDisplayLimit = computed(() =>
+  kwicStore.displayLimit != null ? kwicStore.displayLimit.toLocaleString(locale.value) : "",
+);
 
 const formattedIntro = i18n.kwicIntro;
 

--- a/src/pages/KWICPage.vue
+++ b/src/pages/KWICPage.vue
@@ -5,7 +5,11 @@
     }}</q-item-label>
     <div class="word-trends-intro lineHeight" v-html="formattedIntro"></div>
   </q-card>
-  <q-banner v-if="kwicStore.errorMessage" rounded class="bg-red-1 text-negative q-mt-md">
+  <q-banner
+    v-if="kwicStore.errorMessage"
+    rounded
+    class="bg-red-1 text-negative q-mt-md"
+  >
     {{ $t("kwicFetchError") }}
     <span v-if="kwicStore.errorMessage"> {{ kwicStore.errorMessage }}</span>
   </q-banner>
@@ -16,6 +20,18 @@
     <div class="q-pb-md">
       <ShowData :filterSelections="'KWIC'" />
     </div>
+    <q-banner
+      v-if="kwicStore.displayLimited"
+      dense
+      class="bg-orange-1 text-orange-9 text-caption q-mb-sm"
+    >
+      {{
+        $t("kwicDisplayLimitBanner", {
+          total: kwicStore.totalHits.toLocaleString("sv-SE"),
+          limit: kwicStore.displayLimit.toLocaleString("sv-SE"),
+        })
+      }}
+    </q-banner>
     <div v-if="!loading" class="q-pb-xl">
       <kwicDataTable />
     </div>
@@ -30,7 +46,6 @@
       />
       >
     </div> -->
-
   </div>
 </template>
 
@@ -42,7 +57,6 @@ import { metaDataStore } from "src/stores/metaDataStore.js";
 import { kwicDataStore } from "src/stores/kwicDataStore";
 import i18n from "src/i18n/sv";
 import { ref, watch, onMounted } from "vue";
-
 
 const metaStore = metaDataStore();
 const kwicStore = kwicDataStore();
@@ -73,7 +87,7 @@ watch(
     loading.value = false;
 
     metaStore.cancelSubmitKwicEvent();
-  }
+  },
 );
 
 const cancelFetch = () => {

--- a/src/stores/kwicDataStore.js
+++ b/src/stores/kwicDataStore.js
@@ -56,6 +56,8 @@ export const kwicDataStore = defineStore("kwicData", {
     isPageLoading: false,
     estimatedHits: null,
     inVocabulary: null,
+    displayLimited: false,
+    displayLimit: null,
     requestSequence: 0,
     estimateRequestSequence: 0,
     pageRequestSequence: 0,
@@ -96,6 +98,8 @@ export const kwicDataStore = defineStore("kwicData", {
       this.totalPages = 0;
       this.expiresAt = null;
       this.archiveRetrievalUrl = null;
+      this.displayLimited = false;
+      this.displayLimit = null;
       this.pagination = {
         ...this.pagination,
         page: 1,
@@ -109,7 +113,6 @@ export const kwicDataStore = defineStore("kwicData", {
         lemmatized: this.lemmatizeSearch,
         words_before: this.wordsLeft,
         words_after: this.wordsRight,
-        cut_off: this.cutOff,
         filters: metaDataStore().getSelectedKwicTicketFilters(),
       };
     },
@@ -241,6 +244,8 @@ export const kwicDataStore = defineStore("kwicData", {
         this.kwicData = response.data.kwic_list;
         this.totalHits = response.data.total_hits;
         this.totalPages = response.data.total_pages;
+        this.displayLimited = response.data.display_limited ?? false;
+        this.displayLimit = response.data.display_limit ?? null;
         this.expiresAt = response.data.expires_at;
         this.pagination = {
           ...this.pagination,

--- a/src/stores/kwicDataStore.js
+++ b/src/stores/kwicDataStore.js
@@ -28,7 +28,6 @@ export const kwicDataStore = defineStore("kwicData", {
   state: () => ({
     wordsLeft: 5,
     wordsRight: 5,
-    cutOff: 100000,
     kwicData: [],
     searchText: "",
     columnNames: {
@@ -288,7 +287,6 @@ export const kwicDataStore = defineStore("kwicData", {
           words_before: this.wordsLeft,
           words_after: this.wordsRight,
           lemmatized: this.lemmatizeSearch,
-          ...(this.cutOff !== null && { cut_off: this.cutOff }),
         };
 
         const queryString = metaDataStore().getSelectedParams(additionalParams);

--- a/src/stores/kwicDataStore.js
+++ b/src/stores/kwicDataStore.js
@@ -253,7 +253,10 @@ export const kwicDataStore = defineStore("kwicData", {
           rowsPerPage,
           sortBy,
           descending,
-          rowsNumber: response.data.total_hits,
+          rowsNumber:
+            response.data.display_limited && response.data.display_limit != null
+              ? Math.min(response.data.total_hits, response.data.display_limit)
+              : response.data.total_hits,
         };
 
         return response.data;


### PR DESCRIPTION
- Add displayLimited/displayLimit to kwicDataStore state
- Consume display_limited and display_limit from page-result response
- Reset cap state on new query
- Remove silent cut_off from buildKwicTicketPayload
- Show orange info banner in KWICPage when result is display-capped
- Add kwicDisplayLimitBanner i18n key in sv and en-US

Closes #204