### PR TITLE
Enhance KWIC search experience with hit estimation and display limit feedback

### DIFF
--- a/src/components/toolsFilterData/inputNrOfWords.vue
+++ b/src/components/toolsFilterData/inputNrOfWords.vue
@@ -43,29 +43,10 @@
       </q-input>
     </div>
   </q-card-section>
-  <q-select
-    v-model="kwicStore.cutOff"
-    :options="cutOffOptions"
-    emit-value
-    map-options
-    outlined
-    :label="$t('nrCutOffKWIC')"
-    class="bg-white q-mt-sm"
-    color="accent"
-  />
 </template>
 
 <script setup>
-import { useI18n } from "vue-i18n";
 import { kwicDataStore } from "src/stores/kwicDataStore.js";
 
-const { t } = useI18n();
 const kwicStore = kwicDataStore();
-
-const cutOffOptions = [
-  { label: "100 000", value: 100000 },
-  { label: "1 000 000", value: 1000000 },
-  { label: "10 000 000", value: 10000000 },
-  { label: t("allHits"), value: null },
-];
 </script>

--- a/src/components/toolsFilterData/kwicEstimate.vue
+++ b/src/components/toolsFilterData/kwicEstimate.vue
@@ -1,0 +1,45 @@
+<template>
+  <div v-if="show" class="q-mt-sm">
+    <q-banner
+      v-if="!kwicStore.inVocabulary"
+      dense
+      class="bg-grey-2 text-grey-7 text-caption"
+    >
+      {{ $t("kwicEstimateNotInVocabulary") }}
+    </q-banner>
+    <q-banner
+      v-else-if="isHighCount"
+      dense
+      class="bg-orange-1 text-orange-9 text-caption"
+    >
+      ~{{ formattedHits }} {{ $t("kwicEstimateHits") }} —
+      {{ $t("kwicEstimateHighWarning") }}
+    </q-banner>
+    <q-banner v-else dense class="bg-green-1 text-green-9 text-caption">
+      ~{{ formattedHits }} {{ $t("kwicEstimateHits") }}
+    </q-banner>
+  </div>
+</template>
+
+<script setup>
+import { computed } from "vue";
+import { kwicDataStore } from "src/stores/kwicDataStore";
+
+const HIGH_HIT_THRESHOLD = 10000;
+
+const kwicStore = kwicDataStore();
+
+const show = computed(
+  () => kwicStore.inVocabulary !== null
+);
+
+const isHighCount = computed(
+  () => kwicStore.estimatedHits != null && kwicStore.estimatedHits >= HIGH_HIT_THRESHOLD
+);
+
+const formattedHits = computed(() =>
+  kwicStore.estimatedHits != null
+    ? kwicStore.estimatedHits.toLocaleString("sv-SE")
+    : ""
+);
+</script>

--- a/src/components/toolsFilterData/searchBar.vue
+++ b/src/components/toolsFilterData/searchBar.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script setup>
-import { computed, watch } from "vue";
+import { computed, watch, onBeforeUnmount } from "vue";
 import { kwicDataStore } from "src/stores/kwicDataStore";
 import { metaDataStore } from "src/stores/metaDataStore";
 import { nGramDataStore } from "src/stores/nGramDataStore";
@@ -67,20 +67,26 @@ const handleEnter = () => {
 let estimateDebounceTimer = null;
 
 watch(
-  () => route.path === "/tools/kwic" ? kwicStore.searchText : null,
+  () => (route.path === "/tools/kwic" ? kwicStore.searchText : null),
   (newWord) => {
     if (route.path !== "/tools/kwic") return;
     clearTimeout(estimateDebounceTimer);
+    kwicStore.estimatedHits = null;
+    kwicStore.inVocabulary = null;
     if (!newWord || !newWord.trim()) {
-      kwicStore.estimatedHits = null;
-      kwicStore.inVocabulary = null;
       return;
     }
     estimateDebounceTimer = setTimeout(() => {
-      kwicStore.fetchEstimate(newWord);
+      if (route.path === "/tools/kwic") {
+        kwicStore.fetchEstimate(newWord);
+      }
     }, 400);
-  }
+  },
 );
+
+onBeforeUnmount(() => {
+  clearTimeout(estimateDebounceTimer);
+});
 </script>
 
 <style scoped></style>

--- a/src/components/toolsFilterData/searchBar.vue
+++ b/src/components/toolsFilterData/searchBar.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script setup>
-import { computed } from "vue";
+import { computed, watch } from "vue";
 import { kwicDataStore } from "src/stores/kwicDataStore";
 import { metaDataStore } from "src/stores/metaDataStore";
 import { nGramDataStore } from "src/stores/nGramDataStore";
@@ -63,6 +63,24 @@ const handleEnter = () => {
     }
   }
 };
+
+let estimateDebounceTimer = null;
+
+watch(
+  () => route.path === "/tools/kwic" ? kwicStore.searchText : null,
+  (newWord) => {
+    if (route.path !== "/tools/kwic") return;
+    clearTimeout(estimateDebounceTimer);
+    if (!newWord || !newWord.trim()) {
+      kwicStore.estimatedHits = null;
+      kwicStore.inVocabulary = null;
+      return;
+    }
+    estimateDebounceTimer = setTimeout(() => {
+      kwicStore.fetchEstimate(newWord);
+    }, 400);
+  }
+);
 </script>
 
 <style scoped></style>

--- a/src/components/toolsFilters.vue
+++ b/src/components/toolsFilters.vue
@@ -20,6 +20,7 @@
   </q-card-section>
   <q-card-section v-else-if="currentPath === '/tools/kwic'">
     <searchBar />
+    <kwicEstimate />
     <toggleSwitch
       class="q-mt-md"
       :label="$t('lemmaResultLabel')"
@@ -62,6 +63,7 @@ import searchBarAdd from "src/components/toolsFilterData/searchBarAdd.vue";
 import { computed } from "vue";
 import { useRoute } from "vue-router";
 import searchBar from "src/components/toolsFilterData/searchBar.vue";
+import kwicEstimate from "src/components/toolsFilterData/kwicEstimate.vue";
 import inputNrOfWords from "src/components/toolsFilterData/inputNrOfWords.vue";
 import toggleSwitch from "src/components/toolsFilterData/toggleSwitch.vue";
 import nGramWidth from "src/components/toolsFilterData/nGramWidth.vue";

--- a/src/i18n/en-US/index.js
+++ b/src/i18n/en-US/index.js
@@ -45,6 +45,8 @@ export default {
   kwicEstimateHits: "estimated hits",
   kwicEstimateNotInVocabulary: "The word was not found in the vocabulary",
   kwicEstimateHighWarning: "The search may take a long time",
+  kwicDisplayLimitBanner:
+    "The search has ~{total} hits. The table shows the first {limit}. Download to retrieve all.",
   accessibility: {
     loadingResults: "Loading results, please wait...",
     ticketExpired: "The results have expired. Please submit a new search.",

--- a/src/i18n/en-US/index.js
+++ b/src/i18n/en-US/index.js
@@ -15,9 +15,12 @@ export default {
   downloadFeedback: {
     preparing: "Preparing download...",
     archiveBuilding: "Building archive…",
-    archiveBuildingHint: "Keep this open to wait, or copy the link and close to fetch later.",
-    archiveLinkCopiedClose: "Link copied — close to fetch later, or keep waiting here.",
-    archiveAborted: "Link saved — open it to download the archive when it is ready.",
+    archiveBuildingHint:
+      "Keep this open to wait, or copy the link and close to fetch later.",
+    archiveLinkCopiedClose:
+      "Link copied — close to fetch later, or keep waiting here.",
+    archiveAborted:
+      "Link saved — open it to download the archive when it is ready.",
     success: "The download has started.",
     error: "Could not start the download.",
     archiveGenerationFailed: "Archive generation failed.",
@@ -39,6 +42,9 @@ export default {
     copyLink: "Copy retrieval link",
     linkCopied: "Link copied!",
   },
+  kwicEstimateHits: "estimated hits",
+  kwicEstimateNotInVocabulary: "The word was not found in the vocabulary",
+  kwicEstimateHighWarning: "The search may take a long time",
   accessibility: {
     loadingResults: "Loading results, please wait...",
     ticketExpired: "The results have expired. Please submit a new search.",

--- a/src/i18n/en-US/index.js
+++ b/src/i18n/en-US/index.js
@@ -42,5 +42,7 @@ export default {
   accessibility: {
     loadingResults: "Loading results, please wait...",
     ticketExpired: "The results have expired. Please submit a new search.",
+    kwicTicketTimeout: "The search timed out. Please try again.",
+    kwicQueryFailed: "KWIC query failed.",
   },
 };

--- a/src/i18n/sv/index.js
+++ b/src/i18n/sv/index.js
@@ -132,6 +132,8 @@ export default {
   kwicEstimateHits: "Uppskattade träffar",
   kwicEstimateNotInVocabulary: "Ordet hittades inte i vokabulären",
   kwicEstimateHighWarning: "Sökningen kan ta lång tid",
+  kwicDisplayLimitBanner:
+    "Sökningen har ~{total} träffar. Tabellen visar de första {limit}. Ladda ner för att hämta alla.",
 
   speechesNoTools: "Filtrera ovan med hjälp av 'Filtrera på metadata'",
 
@@ -194,9 +196,12 @@ export default {
   downloadFeedback: {
     preparing: "Förbereder nedladdning...",
     archiveBuilding: "Arkivet byggs…",
-    archiveBuildingHint: "Behåll denna ruta öppen om du vill vänta, eller kopiera länken och stäng för att hämta senare.",
-    archiveLinkCopiedClose: "Länk kopierad — stäng för att hämta senare, eller vänta här.",
-    archiveAborted: "Länken är sparad — öppna den för att hämta arkivet när det är klart.",
+    archiveBuildingHint:
+      "Behåll denna ruta öppen om du vill vänta, eller kopiera länken och stäng för att hämta senare.",
+    archiveLinkCopiedClose:
+      "Länk kopierad — stäng för att hämta senare, eller vänta här.",
+    archiveAborted:
+      "Länken är sparad — öppna den för att hämta arkivet när det är klart.",
     success: "Nedladdningen har startat.",
     error: "Kunde inte starta nedladdningen.",
     archiveGenerationFailed: "Arkivgenerering misslyckades.",

--- a/src/i18n/sv/index.js
+++ b/src/i18n/sv/index.js
@@ -129,6 +129,9 @@ export default {
   nrOfWordsRight: "Höger",
   nrCutOffKWIC: "Max antal träffar att visa/ladda ner",
   allHits: "Alla träffar",
+  kwicEstimateHits: "Uppskattade träffar",
+  kwicEstimateNotInVocabulary: "Ordet hittades inte i vokabulären",
+  kwicEstimateHighWarning: "Sökningen kan ta lång tid",
 
   speechesNoTools: "Filtrera ovan med hjälp av 'Filtrera på metadata'",
 

--- a/src/i18n/sv/index.js
+++ b/src/i18n/sv/index.js
@@ -127,8 +127,6 @@ export default {
   nrOfWordsSearch: "Sökord",
   nrOfWordsLeft: "Vänster",
   nrOfWordsRight: "Höger",
-  nrCutOffKWIC: "Max antal träffar att visa/ladda ner",
-  allHits: "Alla träffar",
   kwicEstimateHits: "Uppskattade träffar",
   kwicEstimateNotInVocabulary: "Ordet hittades inte i vokabulären",
   kwicEstimateHighWarning: "Sökningen kan ta lång tid",

--- a/src/i18n/sv/index.js
+++ b/src/i18n/sv/index.js
@@ -682,6 +682,8 @@ export default {
     noResultsTip:
       "Försök igen med ett annat sökord, eller andra filtreringsalternativ.",
     ticketExpired: "Resultaten har gått ut. Vänligen gör en ny sökning.",
+    kwicTicketTimeout: "Sökningen tog för lång tid. Vänligen försök igen.",
+    kwicQueryFailed: "KWIC-sökningen misslyckades.",
 
     errorMessage404: "Hoppsan, här fanns inget!",
     errorMessageButton: "Tillbaka till startsidan",

--- a/src/pages/DownloadRetrievalPage.vue
+++ b/src/pages/DownloadRetrievalPage.vue
@@ -30,7 +30,7 @@
         </q-card-section>
         <q-card-actions vertical align="left">
           <q-btn
-            color="primary"
+            color="accent"
             icon="download"
             no-caps
             :label="$t('downloadRetrievalPage.downloadButton')"

--- a/src/pages/KWICPage.vue
+++ b/src/pages/KWICPage.vue
@@ -27,8 +27,8 @@
     >
       {{
         $t("kwicDisplayLimitBanner", {
-          total: kwicStore.totalHits.toLocaleString("sv-SE"),
-          limit: kwicStore.displayLimit.toLocaleString("sv-SE"),
+          total: formattedTotalHits,
+          limit: formattedDisplayLimit,
         })
       }}
     </q-banner>
@@ -56,10 +56,19 @@ import loadingIcon from "src/components/loadingIcon.vue";
 import { metaDataStore } from "src/stores/metaDataStore.js";
 import { kwicDataStore } from "src/stores/kwicDataStore";
 import i18n from "src/i18n/sv";
-import { ref, watch, onMounted } from "vue";
+import { ref, watch, onMounted, computed } from "vue";
+import { useI18n } from "vue-i18n";
 
+const { locale } = useI18n();
 const metaStore = metaDataStore();
 const kwicStore = kwicDataStore();
+
+const formattedTotalHits = computed(() =>
+  kwicStore.totalHits != null ? kwicStore.totalHits.toLocaleString(locale.value) : "",
+);
+const formattedDisplayLimit = computed(() =>
+  kwicStore.displayLimit != null ? kwicStore.displayLimit.toLocaleString(locale.value) : "",
+);
 
 const formattedIntro = i18n.kwicIntro;
 

--- a/src/pages/KWICPage.vue
+++ b/src/pages/KWICPage.vue
@@ -5,7 +5,11 @@
     }}</q-item-label>
     <div class="word-trends-intro lineHeight" v-html="formattedIntro"></div>
   </q-card>
-  <q-banner v-if="kwicStore.errorMessage" rounded class="bg-red-1 text-negative q-mt-md">
+  <q-banner
+    v-if="kwicStore.errorMessage"
+    rounded
+    class="bg-red-1 text-negative q-mt-md"
+  >
     {{ $t("kwicFetchError") }}
     <span v-if="kwicStore.errorMessage"> {{ kwicStore.errorMessage }}</span>
   </q-banner>
@@ -16,6 +20,18 @@
     <div class="q-pb-md">
       <ShowData :filterSelections="'KWIC'" />
     </div>
+    <q-banner
+      v-if="kwicStore.displayLimited"
+      dense
+      class="bg-orange-1 text-orange-9 text-caption q-mb-sm"
+    >
+      {{
+        $t("kwicDisplayLimitBanner", {
+          total: kwicStore.totalHits.toLocaleString("sv-SE"),
+          limit: kwicStore.displayLimit.toLocaleString("sv-SE"),
+        })
+      }}
+    </q-banner>
     <div v-if="!loading" class="q-pb-xl">
       <kwicDataTable />
     </div>
@@ -30,7 +46,6 @@
       />
       >
     </div> -->
-
   </div>
 </template>
 
@@ -42,7 +57,6 @@ import { metaDataStore } from "src/stores/metaDataStore.js";
 import { kwicDataStore } from "src/stores/kwicDataStore";
 import i18n from "src/i18n/sv";
 import { ref, watch, onMounted } from "vue";
-
 
 const metaStore = metaDataStore();
 const kwicStore = kwicDataStore();
@@ -73,7 +87,7 @@ watch(
     loading.value = false;
 
     metaStore.cancelSubmitKwicEvent();
-  }
+  },
 );
 
 const cancelFetch = () => {

--- a/src/stores/kwicDataStore.js
+++ b/src/stores/kwicDataStore.js
@@ -56,6 +56,8 @@ export const kwicDataStore = defineStore("kwicData", {
     isPageLoading: false,
     estimatedHits: null,
     inVocabulary: null,
+    displayLimited: false,
+    displayLimit: null,
     requestSequence: 0,
     estimateRequestSequence: 0,
     pageRequestSequence: 0,
@@ -96,6 +98,8 @@ export const kwicDataStore = defineStore("kwicData", {
       this.totalPages = 0;
       this.expiresAt = null;
       this.archiveRetrievalUrl = null;
+      this.displayLimited = false;
+      this.displayLimit = null;
       this.pagination = {
         ...this.pagination,
         page: 1,
@@ -109,7 +113,6 @@ export const kwicDataStore = defineStore("kwicData", {
         lemmatized: this.lemmatizeSearch,
         words_before: this.wordsLeft,
         words_after: this.wordsRight,
-        cut_off: this.cutOff,
         filters: metaDataStore().getSelectedKwicTicketFilters(),
       };
     },
@@ -241,6 +244,8 @@ export const kwicDataStore = defineStore("kwicData", {
         this.kwicData = response.data.kwic_list;
         this.totalHits = response.data.total_hits;
         this.totalPages = response.data.total_pages;
+        this.displayLimited = response.data.display_limited ?? false;
+        this.displayLimit = response.data.display_limit ?? null;
         this.expiresAt = response.data.expires_at;
         this.pagination = {
           ...this.pagination,

--- a/src/stores/kwicDataStore.js
+++ b/src/stores/kwicDataStore.js
@@ -28,7 +28,6 @@ export const kwicDataStore = defineStore("kwicData", {
   state: () => ({
     wordsLeft: 5,
     wordsRight: 5,
-    cutOff: 100000,
     kwicData: [],
     searchText: "",
     columnNames: {
@@ -288,7 +287,6 @@ export const kwicDataStore = defineStore("kwicData", {
           words_before: this.wordsLeft,
           words_after: this.wordsRight,
           lemmatized: this.lemmatizeSearch,
-          ...(this.cutOff !== null && { cut_off: this.cutOff }),
         };
 
         const queryString = metaDataStore().getSelectedParams(additionalParams);

--- a/src/stores/kwicDataStore.js
+++ b/src/stores/kwicDataStore.js
@@ -253,7 +253,10 @@ export const kwicDataStore = defineStore("kwicData", {
           rowsPerPage,
           sortBy,
           descending,
-          rowsNumber: response.data.total_hits,
+          rowsNumber:
+            response.data.display_limited && response.data.display_limit != null
+              ? Math.min(response.data.total_hits, response.data.display_limit)
+              : response.data.total_hits,
         };
 
         return response.data;

--- a/src/stores/kwicDataStore.js
+++ b/src/stores/kwicDataStore.js
@@ -57,6 +57,7 @@ export const kwicDataStore = defineStore("kwicData", {
     estimatedHits: null,
     inVocabulary: null,
     requestSequence: 0,
+    estimateRequestSequence: 0,
     pageRequestSequence: 0,
     pagination: {
       sortBy: DEFAULT_SORT_BY,
@@ -120,6 +121,7 @@ export const kwicDataStore = defineStore("kwicData", {
         return;
       }
 
+      const requestId = ++this.estimateRequestSequence;
       const filters = metaDataStore().getSelectedKwicTicketFilters();
       const params = { word: word.trim() };
 
@@ -128,13 +130,16 @@ export const kwicDataStore = defineStore("kwicData", {
       if (filters.party_id?.length) params.party_id = filters.party_id;
       if (filters.who?.length) params.who = filters.who;
       if (filters.gender_id?.length) params.gender_id = filters.gender_id;
-      if (filters.chamber_abbrev?.length) params.chamber_abbrev = filters.chamber_abbrev;
+      if (filters.chamber_abbrev?.length)
+        params.chamber_abbrev = filters.chamber_abbrev;
 
       try {
         const response = await api.get("/tools/kwic/estimate", { params });
+        if (requestId !== this.estimateRequestSequence) return;
         this.estimatedHits = response.data.estimated_hits;
         this.inVocabulary = response.data.in_vocabulary;
       } catch {
+        if (requestId !== this.estimateRequestSequence) return;
         this.estimatedHits = null;
         this.inVocabulary = null;
       }
@@ -169,7 +174,9 @@ export const kwicDataStore = defineStore("kwicData", {
         }
 
         if (response.data.status === "error") {
-          throw new Error(response.data.error || i18n.accessibility.kwicQueryFailed);
+          throw new Error(
+            response.data.error || i18n.accessibility.kwicQueryFailed,
+          );
         }
 
         const delayMs = getTicketPollDelayMs(

--- a/src/stores/kwicDataStore.js
+++ b/src/stores/kwicDataStore.js
@@ -54,6 +54,8 @@ export const kwicDataStore = defineStore("kwicData", {
     archiveRetrievalUrl: null,
     isLoading: false,
     isPageLoading: false,
+    estimatedHits: null,
+    inVocabulary: null,
     requestSequence: 0,
     pageRequestSequence: 0,
     pagination: {
@@ -109,6 +111,33 @@ export const kwicDataStore = defineStore("kwicData", {
         cut_off: this.cutOff,
         filters: metaDataStore().getSelectedKwicTicketFilters(),
       };
+    },
+
+    async fetchEstimate(word) {
+      if (!word || !word.trim()) {
+        this.estimatedHits = null;
+        this.inVocabulary = null;
+        return;
+      }
+
+      const filters = metaDataStore().getSelectedKwicTicketFilters();
+      const params = { word: word.trim() };
+
+      if (filters.from_year != null) params.from_year = filters.from_year;
+      if (filters.to_year != null) params.to_year = filters.to_year;
+      if (filters.party_id?.length) params.party_id = filters.party_id;
+      if (filters.who?.length) params.who = filters.who;
+      if (filters.gender_id?.length) params.gender_id = filters.gender_id;
+      if (filters.chamber_abbrev?.length) params.chamber_abbrev = filters.chamber_abbrev;
+
+      try {
+        const response = await api.get("/tools/kwic/estimate", { params });
+        this.estimatedHits = response.data.estimated_hits;
+        this.inVocabulary = response.data.in_vocabulary;
+      } catch {
+        this.estimatedHits = null;
+        this.inVocabulary = null;
+      }
     },
 
     getKwicResultsPath(search) {

--- a/src/stores/kwicDataStore.js
+++ b/src/stores/kwicDataStore.js
@@ -1,7 +1,6 @@
 import { defineStore } from "pinia";
 import { api } from "boot/axios";
 import axios from "axios";
-import { Notify, copyToClipboard } from "quasar";
 import { metaDataStore } from "./metaDataStore";
 import { downloadDataStore } from "./downloadDataStore";
 import i18n from "src/i18n/sv/index.js";
@@ -52,8 +51,6 @@ export const kwicDataStore = defineStore("kwicData", {
     expiresAt: null,
     errorMessage: "",
     hasSubmittedQuery: false,
-    archiveTicketId: null,
-    archiveTicketStatus: null,
     archiveRetrievalUrl: null,
     isLoading: false,
     isPageLoading: false,
@@ -89,20 +86,12 @@ export const kwicDataStore = defineStore("kwicData", {
       return search;
     },
 
-    resetArchiveTicketState() {
-      this.archiveTicketId = null;
-      this.archiveTicketStatus = null;
-      this.archiveRetrievalUrl = null;
-    },
-
     resetTicketState() {
       this.kwicData = [];
       this.ticketId = null;
       this.totalHits = 0;
       this.totalPages = 0;
       this.expiresAt = null;
-      this.archiveTicketId = null;
-      this.archiveTicketStatus = null;
       this.archiveRetrievalUrl = null;
       this.pagination = {
         ...this.pagination,
@@ -151,7 +140,7 @@ export const kwicDataStore = defineStore("kwicData", {
         }
 
         if (response.data.status === "error") {
-          throw new Error(response.data.error || "KWIC query failed");
+          throw new Error(response.data.error || i18n.accessibility.kwicQueryFailed);
         }
 
         const delayMs = getTicketPollDelayMs(
@@ -163,7 +152,7 @@ export const kwicDataStore = defineStore("kwicData", {
         });
       }
 
-      throw new Error("KWIC ticket timed out");
+      throw new Error(i18n.accessibility.kwicTicketTimeout);
     },
 
     async fetchKwicPage({
@@ -341,108 +330,39 @@ export const kwicDataStore = defineStore("kwicData", {
       }
     },
 
-    async _downloadKwicArchive(archiveFormat, fallbackFilename, downloadKey) {
-      if (!this.ticketId) return false;
-      if (downloadKey && downloadDataStore().isDownloadActive(downloadKey)) return false;
-
+    async downloadKwicArchive(format = "jsonl_gz") {
+      if (!this.ticketId) {
+        this.archiveRetrievalUrl = null;
+        this.errorMessage = i18n.accessibility.ticketExpired;
+        return false;
+      }
       this.errorMessage = "";
-      this.resetArchiveTicketState();
-      downloadDataStore().setDownloadActive(downloadKey, true);
-
-      let dismissLinkNotify = null;
-      let abortedByUser = false;
+      this.archiveRetrievalUrl = null;
 
       try {
-        // 1. Request archive ticket (~200ms round-trip)
+        // 1. Request archive ticket
         const prepareResponse = await api.post(
-          `/tools/kwic/archive/${encodeURIComponent(this.ticketId)}?archive_format=${encodeURIComponent(archiveFormat)}`,
+          `/tools/kwic/archive/${encodeURIComponent(this.ticketId)}?archive_format=${encodeURIComponent(format)}`,
         );
         const archiveTicketId = prepareResponse.data.archive_ticket_id;
-        this.archiveTicketId = archiveTicketId;
-        this.archiveTicketStatus = "pending";
         this.archiveRetrievalUrl = prepareResponse.data.retrieval_url || null;
 
-        // 2. Immediately show a persistent notification with the retrieval link
-        const retrievalUrl = window.location.origin + "/download/" + archiveTicketId;
-        const buildingHint =
-          i18n.downloadFeedback?.archiveBuildingHint ||
-          "Behåll denna ruta öppen om du vill vänta, eller kopiera länken och stäng för att hämta senare.";
-        dismissLinkNotify = Notify.create({
-          message:
-            (i18n.downloadFeedback?.archiveBuilding || "Arkivet byggs…") + " " + buildingHint,
-          color: "blue-8",
-          icon: "hourglass_top",
-          timeout: 0,
-          position: "top",
-          multiLine: true,
-          actions: [
-            {
-              label: i18n.downloadRetrievalPage?.copyLink || "Kopiera hämtningslänk",
-              color: "yellow",
-              handler: () => {
-                const prevDismiss = dismissLinkNotify;
-                copyToClipboard(retrievalUrl);
-                const copiedHint =
-                  i18n.downloadFeedback?.archiveLinkCopiedClose ||
-                  "Länk kopierad — stäng för att hämta senare, eller vänta här.";
-                dismissLinkNotify = Notify.create({
-                  message: copiedHint,
-                  color: "blue-8",
-                  icon: "check",
-                  timeout: 0,
-                  position: "top",
-                  multiLine: true,
-                  actions: [
-                    {
-                      icon: "close",
-                      color: "white",
-                      round: true,
-                      handler: () => {
-                        abortedByUser = true;
-                        if (typeof dismissLinkNotify === "function") {
-                          dismissLinkNotify();
-                          dismissLinkNotify = null;
-                        }
-                      },
-                    },
-                  ],
-                });
-                if (typeof prevDismiss === "function") prevDismiss();
-              },
-            },
-          ],
-        });
-
-        // 3. Poll until ready via generic downloads endpoint
+        // 2. Poll until ready via generic downloads endpoint
         await pollArchiveTicket(api, {
           statusUrl: `/downloads/${archiveTicketId}`,
-          onStatus: (status) => {
-            this.archiveTicketStatus = status;
-          },
         });
 
-        // 4. Download the artifact — skip if user said "I'll fetch it later"
-        if (abortedByUser) {
-          Notify.create({
-            message:
-              i18n.downloadFeedback?.archiveAborted ||
-              "Nedladdning avbruten — använd länken för att hämta filen när den är klar.",
-            color: "info",
-            icon: "link",
-            timeout: 6000,
-            position: "top",
-          });
-          return true;
-        }
-
+        // 3. Download the artifact
         const downloadResponse = await api.get(
           `/downloads/${archiveTicketId}/download`,
           { responseType: "blob" },
         );
+        const archiveExtensions = { csv_gz: "csv.gz", jsonl_gz: "jsonl.gz" };
+        const fileExtension = archiveExtensions[format] ?? format;
         downloadDataStore().setupDownload(
           downloadDataStore().getFilenameFromDisposition(
             downloadResponse.headers,
-            fallbackFilename,
+            `kwic_archive_${this.ticketId}.${fileExtension}`,
           ),
           downloadResponse.data,
         );
@@ -454,179 +374,17 @@ export const kwicDataStore = defineStore("kwicData", {
         } else {
           this.errorMessage = this.getErrorMessage(error);
         }
-        Notify.create({
-          type: "negative",
-          message: this.errorMessage,
-          timeout: 4000,
-          position: "top",
-        });
-        console.error(`Error downloading KWIC archive (${archiveFormat}):`, error);
+        console.error("Error downloading KWIC archive:", error);
         return false;
-      } finally {
-        if (typeof dismissLinkNotify === "function") {
-          dismissLinkNotify();
-          dismissLinkNotify = null;
-        }
-        downloadDataStore().setDownloadActive(downloadKey, false);
       }
     },
 
-    async _downloadKwicSpeechesArchive(archiveFormat, fallbackFilename, downloadKey) {
-      if (!this.ticketId) return false;
-      if (downloadKey && downloadDataStore().isDownloadActive(downloadKey)) return false;
-
-      this.errorMessage = "";
-      this.resetArchiveTicketState();
-      downloadDataStore().setDownloadActive(downloadKey, true);
-
-      let dismissLinkNotify = null;
-      let abortedByUser = false;
-
-      try {
-        const prepareResponse = await api.post(
-          `/tools/speeches/archive/${encodeURIComponent(this.ticketId)}?archive_format=${encodeURIComponent(archiveFormat)}`,
-        );
-        const archiveTicketId = prepareResponse.data.archive_ticket_id;
-        this.archiveTicketId = archiveTicketId;
-        this.archiveTicketStatus = "pending";
-        this.archiveRetrievalUrl = prepareResponse.data.retrieval_url || null;
-
-        const retrievalUrl = window.location.origin + "/download/" + archiveTicketId;
-        const buildingHint =
-          i18n.downloadFeedback?.archiveBuildingHint ||
-          "Behåll denna ruta öppen om du vill vänta, eller kopiera länken och stäng för att hämta senare.";
-        dismissLinkNotify = Notify.create({
-          message:
-            (i18n.downloadFeedback?.archiveBuilding || "Arkivet byggs…") + " " + buildingHint,
-          color: "blue-8",
-          icon: "hourglass_top",
-          timeout: 0,
-          position: "top",
-          multiLine: true,
-          actions: [
-            {
-              label: i18n.downloadRetrievalPage?.copyLink || "Kopiera hämtningslänk",
-              color: "yellow",
-              handler: () => {
-                const prevDismiss = dismissLinkNotify;
-                copyToClipboard(retrievalUrl);
-                const copiedHint =
-                  i18n.downloadFeedback?.archiveLinkCopiedClose ||
-                  "Länk kopierad — stäng för att hämta senare, eller vänta här.";
-                dismissLinkNotify = Notify.create({
-                  message: copiedHint,
-                  color: "blue-8",
-                  icon: "check",
-                  timeout: 0,
-                  position: "top",
-                  multiLine: true,
-                  actions: [
-                    {
-                      icon: "close",
-                      color: "white",
-                      round: true,
-                      handler: () => {
-                        abortedByUser = true;
-                        if (typeof dismissLinkNotify === "function") {
-                          dismissLinkNotify();
-                          dismissLinkNotify = null;
-                        }
-                      },
-                    },
-                  ],
-                });
-                if (typeof prevDismiss === "function") prevDismiss();
-              },
-            },
-          ],
-        });
-
-        await pollArchiveTicket(api, {
-          statusUrl: `/tools/speeches/archive/status/${archiveTicketId}`,
-          onStatus: (status) => {
-            this.archiveTicketStatus = status;
-          },
-        });
-
-        if (abortedByUser) {
-          Notify.create({
-            message:
-              i18n.downloadFeedback?.archiveAborted ||
-              "Nedladdning avbruten — använd länken för att hämta filen när den är klar.",
-            color: "info",
-            icon: "link",
-            timeout: 6000,
-            position: "top",
-          });
-          return true;
-        }
-
-        const downloadResponse = await api.get(
-          `/tools/speeches/archive/download/${archiveTicketId}`,
-          { responseType: "blob" },
-        );
-        downloadDataStore().setupDownload(
-          downloadDataStore().getFilenameFromDisposition(
-            downloadResponse.headers,
-            fallbackFilename,
-          ),
-          downloadResponse.data,
-        );
-        return true;
-      } catch (error) {
-        if (error.response?.status === 404) {
-          this.errorMessage = i18n.accessibility.ticketExpired;
-          this.resetTicketState();
-        } else {
-          this.errorMessage = this.getErrorMessage(error);
-        }
-        Notify.create({
-          type: "negative",
-          message: this.errorMessage,
-          timeout: 4000,
-          position: "top",
-        });
-        console.error(`Error downloading KWIC speeches archive (${archiveFormat}):`, error);
-        return false;
-      } finally {
-        if (typeof dismissLinkNotify === "function") {
-          dismissLinkNotify();
-          dismissLinkNotify = null;
-        }
-        downloadDataStore().setDownloadActive(downloadKey, false);
-      }
+    async downloadKWICTableExcel() {
+      return this.downloadKwicArchive("xlsx");
     },
 
-    async downloadKwicExcel(downloadKey) {
-      return this._downloadKwicArchive(
-        "xlsx",
-        `kwic_archive_${this.ticketId}.xlsx`,
-        downloadKey,
-      );
-    },
-
-    async downloadKwicCsvGz(downloadKey) {
-      return this._downloadKwicArchive(
-        "csv_gz",
-        `kwic_archive_${this.ticketId}.csv.gz`,
-        downloadKey,
-      );
-    },
-
-    async downloadKwicJsonlGz(downloadKey) {
-      return this._downloadKwicArchive(
-        "jsonl_gz",
-        `kwic_archive_${this.ticketId}.jsonl.gz`,
-        downloadKey,
-      );
-    },
-
-    async downloadKwicSpeechesZip(downloadKey) {
-      return this._downloadKwicSpeechesArchive(
-        "zip",
-        `kwic_speeches_${this.ticketId}.zip`,
-        downloadKey,
-      );
+    async downloadKWICTableCSV() {
+      return this.downloadKwicArchive("csv_gz");
     },
   },
 });

--- a/src/stores/ticketPolling.js
+++ b/src/stores/ticketPolling.js
@@ -1,7 +1,7 @@
 import i18n from "src/i18n/sv/index.js";
 
 export const TICKET_POLL_INTERVAL_MS = 2000;
-export const TICKET_POLL_MAX_ATTEMPTS = 90;
+export const TICKET_POLL_MAX_ATTEMPTS = 300;
 
 export function getTicketPollDelayMs(attempt, retryAfterHeader) {
   const retryAfterSeconds = Number.parseInt(retryAfterHeader, 10);


### PR DESCRIPTION
Implement pre-search hit estimation to provide users with immediate feedback on expected result sizes as they type. Introduce a color-coded banner to indicate manageable results, high counts, or vocabulary issues. Additionally, consume server-provided display cap fields to inform users when results exceed limits, replacing the previous silent cut-off mechanism. Update the download functionality and internationalization strings for improved accessibility and user experience.

Fixes #202, #204