### PR TITLE
feat(kwic): progressive shard delivery for KWIC results

### DIFF
--- a/src/components/kwicDataTable.vue
+++ b/src/components/kwicDataTable.vue
@@ -5,86 +5,44 @@
   <template v-else-if="kwicStore.kwicData && kwicStore.kwicData.length > 0">
     <div class="row q-py-md justify-between">
       <q-item-label class="col-9 q-mt-md" v-if="kwicStore.totalHits > 0">
-        {{ $t("searchResult1") }} <b>{{ formattedTotalHits }}</b>
+        {{ $t("searchResult1") }} <b>{{ kwicStore.totalHits }}</b>
         {{ $t("searchResult2") }}
-        <span v-if="kwicStore.displayLimited" class="text-orange-9">
-          {{ $t("kwicDisplayCapNote", { limit: formattedDisplayLimit }) }}
-        </span>
       </q-item-label>
 
-      <q-btn-dropdown
-        no-caps
-        icon="download"
-        class="text-grey-8 col-3"
-        color="secondary"
-        :label="$t('downloadKWIC')"
-        style="width: fit-content"
-      >
+      <q-btn-dropdown no-caps icon="download" class="text-grey-8 col-3" color="secondary" :label="$t('downloadKWIC')"
+        style="width: fit-content">
         <q-list>
-          <q-item
-            clickable
-            v-close-popup
-            :disable="isDownloadActive(downloadKeys.csv)"
-            @click="downloadKWICTableAsCSV"
-          >
+          <q-item clickable v-close-popup :disable="isDownloadActive(downloadKeys.csv)" @click="downloadKWICTableAsCSV">
             <q-item-section>
               <q-item-label class="row items-center no-wrap">
-                <q-spinner-tail
-                  v-if="isDownloadActive(downloadKeys.csv)"
-                  size="16px"
-                  class="q-mr-sm"
-                />
+                <q-spinner-tail v-if="isDownloadActive(downloadKeys.csv)" size="16px" class="q-mr-sm" />
                 {{ $t('downloadCSV') }}
               </q-item-label>
             </q-item-section>
           </q-item>
-          <q-item
-            clickable
-            v-close-popup
-            :disable="isDownloadActive(downloadKeys.jsonlgz)"
-            @click="downloadKWICTableAsJsonlGz"
-          >
+          <q-item clickable v-close-popup :disable="isDownloadActive(downloadKeys.jsonlgz)"
+            @click="downloadKWICTableAsJsonlGz">
             <q-item-section>
               <q-item-label class="row items-center no-wrap">
-                <q-spinner-tail
-                  v-if="isDownloadActive(downloadKeys.jsonlgz)"
-                  size="16px"
-                  class="q-mr-sm"
-                />
+                <q-spinner-tail v-if="isDownloadActive(downloadKeys.jsonlgz)" size="16px" class="q-mr-sm" />
                 {{ $t('downloadKwicJsonlGzArchive') }}
               </q-item-label>
             </q-item-section>
           </q-item>
-          <q-item
-            clickable
-            v-close-popup
-            :disable="isDownloadActive(downloadKeys.excel)"
-            @click="downloadKWICTableAsExcel"
-          >
+          <q-item clickable v-close-popup :disable="isDownloadActive(downloadKeys.excel)"
+            @click="downloadKWICTableAsExcel">
             <q-item-section>
               <q-item-label class="row items-center no-wrap">
-                <q-spinner-tail
-                  v-if="isDownloadActive(downloadKeys.excel)"
-                  size="16px"
-                  class="q-mr-sm"
-                />
+                <q-spinner-tail v-if="isDownloadActive(downloadKeys.excel)" size="16px" class="q-mr-sm" />
                 {{ $t('downloadExcel') }}
               </q-item-label>
             </q-item-section>
           </q-item>
-          <q-item
-            clickable
-            v-close-popup
-            :disable="isDownloadActive(downloadKeys.speeches)"
-            @click="downloadKWICAsSpeeches"
-          >
+          <q-item clickable v-close-popup :disable="isDownloadActive(downloadKeys.speeches)"
+            @click="downloadKWICAsSpeeches">
             <q-item-section>
               <q-item-label class="row items-center no-wrap">
-                <q-spinner-tail
-                  v-if="isDownloadActive(downloadKeys.speeches)"
-                  size="16px"
-                  class="q-mr-sm"
-                />
+                <q-spinner-tail v-if="isDownloadActive(downloadKeys.speeches)" size="16px" class="q-mr-sm" />
                 {{ $t('downloadSpeechTextArchive') }}
               </q-item-label>
             </q-item-section>
@@ -92,17 +50,9 @@
         </q-list>
       </q-btn-dropdown>
     </div>
-    <q-table
-      ref="KWICTable"
-      :rows="rows"
-      :columns="columns"
-      row-key="unique_id"
-      :rows-per-page-options="[10, 20, 50]"
-      v-model:pagination="pagination"
-      :loading="kwicStore.isLoading || kwicStore.isPageLoading"
-      class="bg-grey-2"
-      @request="onRequest"
-    >
+    <q-table ref="KWICTable" :rows="rows" :columns="columns" row-key="unique_id" :rows-per-page-options="[10, 20, 50]"
+      v-model:pagination="pagination" :loading="kwicStore.isLoading || kwicStore.isPageLoading" class="bg-grey-2"
+      @request="onRequest">
       <template v-slot:loading>
         <q-inner-loading showing class="kwic-table-loading-overlay">
           <q-spinner-tail size="48px" color="accent" :thickness="5" />
@@ -115,12 +65,7 @@
         <q-tr :props="props">
           <q-th v-for="col in props.cols" :key="col.name" :props="props">
             {{ col.label }}
-            <q-icon
-              v-if="col.label === 'Anförande'"
-              name="info_outline"
-              color="accent"
-              class="q-mb-md q-ml-xs"
-            >
+            <q-icon v-if="col.label === 'Anförande'" name="info_outline" color="accent" class="q-mb-md q-ml-xs">
               <q-tooltip>
                 {{ $t("accessibility.tooltipSpeechID") }}
               </q-tooltip>
@@ -130,13 +75,8 @@
       </template>
       <template v-slot:body="props">
         <q-tr :props="props" @click="expandRow(props)" class="cursor-pointer">
-          <q-td
-            v-for="col in props.cols"
-            :key="col.name"
-            :props="props"
-            class="bg-white"
-            :class="props.expand ? 'bg-grey-3' : ''"
-            :style="{
+          <q-td v-for="col in props.cols" :key="col.name" :props="props" class="bg-white"
+            :class="props.expand ? 'bg-grey-3' : ''" :style="{
               'max-width':
                 col.name === 'left_word' || col.name === 'right_word'
                   ? '200px'
@@ -149,15 +89,9 @@
                 col.name === 'left_word' || col.name === 'right_word'
                   ? 'break-word'
                   : 'normal',
-            }"
-          >
-            <q-item-label
-              v-if="col.name === 'party'"
-              :class="
-                col.value === '[-]' ? 'text-italic text-grey-6' : 'text-bold'
-              "
-              :style="{ color: metaStore.getPartyAbbrevColor(col.value) }"
-            >
+            }">
+            <q-item-label v-if="col.name === 'party'" :class="col.value === '[-]' ? 'text-italic text-grey-6' : 'text-bold'
+              " :style="{ color: metaStore.getPartyAbbrevColor(col.value) }">
               {{
                 col.value === "[-]"
                   ? $t("accessibility.metadataMissing")
@@ -167,35 +101,19 @@
                 {{ props.row.party_full }}
               </q-tooltip>
             </q-item-label>
-            <q-item-label
-              v-else-if="col.name === 'node_word'"
-              class="text-bold"
-            >
+            <q-item-label v-else-if="col.name === 'node_word'" class="text-bold">
               {{ col.value }}
             </q-item-label>
-            <q-item-label
-              v-else-if="col.value === 'Okänd' || col.value === 'Okänt'"
-              class="text-italic text-grey-6"
-            >
+            <q-item-label v-else-if="col.value === 'Okänd' || col.value === 'Okänt'" class="text-italic text-grey-6">
               {{ $t("accessibility.metadataMissing") }}
             </q-item-label>
             <q-item-label v-else>
               {{ col.value }}
             </q-item-label>
           </q-td>
-          <q-td
-            auto-width
-            class="bg-white"
-            :class="props.expand ? 'bg-grey-3' : ''"
-          >
-            <q-btn
-              size="sm"
-              color="accent"
-              round
-              dense
-              flat
-              :icon="props.expand ? 'keyboard_arrow_up' : 'keyboard_arrow_down'"
-            />
+          <q-td auto-width class="bg-white" :class="props.expand ? 'bg-grey-3' : ''">
+            <q-btn size="sm" color="accent" round dense flat
+              :icon="props.expand ? 'keyboard_arrow_up' : 'keyboard_arrow_down'" />
           </q-td>
         </q-tr>
         <!-- If row in table is clicked, EXPAND -->
@@ -211,7 +129,6 @@
 
 <script setup>
 import { computed, ref } from "vue";
-import { useI18n } from "vue-i18n";
 import { metaDataStore } from "src/stores/metaDataStore";
 import { kwicDataStore } from "src/stores/kwicDataStore";
 import { downloadDataStore } from "src/stores/downloadDataStore";
@@ -219,17 +136,9 @@ import expandingTableRow from "src/components/expandingTableRow.vue";
 import loadingIcon from "src/components/loadingIcon.vue";
 import noResults from "src/components/noResults.vue";
 
-const { locale } = useI18n();
 const metaStore = metaDataStore();
 const kwicStore = kwicDataStore();
 const downloadStore = downloadDataStore();
-
-const formattedTotalHits = computed(() =>
-  kwicStore.totalHits != null ? kwicStore.totalHits.toLocaleString(locale.value) : "",
-);
-const formattedDisplayLimit = computed(() =>
-  kwicStore.displayLimit != null ? kwicStore.displayLimit.toLocaleString(locale.value) : "",
-);
 
 const downloadKeys = {
   csv: "kwic-csv",

--- a/src/components/kwicDataTable.vue
+++ b/src/components/kwicDataTable.vue
@@ -53,6 +53,17 @@
     <q-table ref="KWICTable" :rows="rows" :columns="columns" row-key="unique_id" :rows-per-page-options="[10, 20, 50]"
       v-model:pagination="pagination" :loading="kwicStore.isLoading || kwicStore.isPageLoading" class="bg-grey-2"
       @request="onRequest">
+      <template v-slot:top-row v-if="kwicStore.isPartial">
+        <q-tr>
+          <q-td :colspan="columns.length + 1" class="q-pa-none">
+            <q-linear-progress :value="kwicStore.shardsTotal > 0 ? kwicStore.shardsComplete / kwicStore.shardsTotal : 0"
+              color="accent" track-color="grey-3" class="q-mb-none" style="height: 6px" />
+            <q-item-label caption class="q-px-sm q-pt-xs text-grey-7">
+              {{ $t('kwicShardProgress', { complete: kwicStore.shardsComplete, total: kwicStore.shardsTotal }) }}
+            </q-item-label>
+          </q-td>
+        </q-tr>
+      </template>
       <template v-slot:loading>
         <q-inner-loading showing class="kwic-table-loading-overlay">
           <q-spinner-tail size="48px" color="accent" :thickness="5" />
@@ -171,6 +182,15 @@ const expandRow = async (props) => {
 
 const onRequest = async ({ pagination }) => {
   if (!kwicStore.useTicketFlow || !kwicStore.ticketId) {
+    return;
+  }
+
+  // Ignore sort changes while results are still loading (PARTIAL)
+  if (
+    kwicStore.isPartial &&
+    (pagination.sortBy !== kwicStore.pagination.sortBy ||
+      pagination.descending !== kwicStore.pagination.descending)
+  ) {
     return;
   }
 

--- a/src/i18n/en-US/index.js
+++ b/src/i18n/en-US/index.js
@@ -42,6 +42,9 @@ export default {
     copyLink: "Copy retrieval link",
     linkCopied: "Link copied!",
   },
+  kwicEstimateHits: "estimated hits",
+  kwicEstimateNotInVocabulary: "The word was not found in the vocabulary",
+  kwicEstimateHighWarning: "The search may take a long time",
   accessibility: {
     loadingResults: "Loading results, please wait...",
     ticketExpired: "The results have expired. Please submit a new search.",

--- a/src/i18n/en-US/index.js
+++ b/src/i18n/en-US/index.js
@@ -42,10 +42,6 @@ export default {
     copyLink: "Copy retrieval link",
     linkCopied: "Link copied!",
   },
-  kwicEstimateHits: "estimated hits",
-  kwicEstimateNotInVocabulary: "The word was not found in the vocabulary",
-  kwicEstimateHighWarning: "The search may take a long time",
-  kwicDisplayCapNote: "The table shows the first {limit}.",
   accessibility: {
     loadingResults: "Loading results, please wait...",
     ticketExpired: "The results have expired. Please submit a new search.",

--- a/src/i18n/en-US/index.js
+++ b/src/i18n/en-US/index.js
@@ -48,4 +48,5 @@ export default {
     kwicTicketTimeout: "The search timed out. Please try again.",
     kwicQueryFailed: "KWIC query failed.",
   },
+  kwicShardProgress: "{complete} of {total} shards loaded",
 };

--- a/src/i18n/sv/index.js
+++ b/src/i18n/sv/index.js
@@ -129,6 +129,9 @@ export default {
   nrOfWordsRight: "Höger",
   nrCutOffKWIC: "Max antal träffar att visa/ladda ner",
   allHits: "Alla träffar",
+  kwicEstimateHits: "Uppskattade träffar",
+  kwicEstimateNotInVocabulary: "Ordet hittades inte i vokabulären",
+  kwicEstimateHighWarning: "Sökningen kan ta lång tid",
 
   speechesNoTools: "Filtrera ovan med hjälp av 'Filtrera på metadata'",
 

--- a/src/i18n/sv/index.js
+++ b/src/i18n/sv/index.js
@@ -702,4 +702,5 @@ export default {
   reportText:
     "För att lämna feedback eller rapportera fel (t ex om segmenteringen av anföranden eller om metadatan kopplade till ledamöter), vänligen kopiera metadatan nedan om detta specifika anförande och gå sedan vidare till SWERIK:s GitHub-sida för att skapa ett diskussionsärende. Klistra där in metadatan och förklara vad som är fel och eventuella ändringsförslag.",
   githubLink: "Gå vidare till SWERIK:s GitHub-sida",
+  kwicShardProgress: "{complete} av {total} delar inladdade",
 };

--- a/src/i18n/sv/index.js
+++ b/src/i18n/sv/index.js
@@ -127,10 +127,8 @@ export default {
   nrOfWordsSearch: "Sökord",
   nrOfWordsLeft: "Vänster",
   nrOfWordsRight: "Höger",
-  kwicEstimateHits: "Uppskattade träffar",
-  kwicEstimateNotInVocabulary: "Ordet hittades inte i vokabulären",
-  kwicEstimateHighWarning: "Sökningen kan ta lång tid",
-  kwicDisplayCapNote: "Tabellen visar de första {limit}.",
+  nrCutOffKWIC: "Max antal träffar att visa/ladda ner",
+  allHits: "Alla träffar",
 
   speechesNoTools: "Filtrera ovan med hjälp av 'Filtrera på metadata'",
 

--- a/src/stores/kwicDataStore.js
+++ b/src/stores/kwicDataStore.js
@@ -57,6 +57,9 @@ export const kwicDataStore = defineStore("kwicData", {
     shardsComplete: 0,
     shardsTotal: 0,
     isPartial: false,
+    estimatedHits: null,
+    inVocabulary: null,
+    estimateRequestSequence: 0,
     requestSequence: 0,
     pageRequestSequence: 0,
     pagination: {
@@ -112,9 +115,40 @@ export const kwicDataStore = defineStore("kwicData", {
         lemmatized: this.lemmatizeSearch,
         words_before: this.wordsLeft,
         words_after: this.wordsRight,
-        cut_off: this.cutOff,
+        ...(this.cutOff !== null && { cut_off: this.cutOff }),
         filters: metaDataStore().getSelectedKwicTicketFilters(),
       };
+    },
+
+    async fetchEstimate(word) {
+      if (!word || !word.trim()) {
+        this.estimatedHits = null;
+        this.inVocabulary = null;
+        return;
+      }
+
+      const requestId = ++this.estimateRequestSequence;
+      const filters = metaDataStore().getSelectedKwicTicketFilters();
+      const params = { word: word.trim() };
+
+      if (filters.from_year != null) params.from_year = filters.from_year;
+      if (filters.to_year != null) params.to_year = filters.to_year;
+      if (filters.party_id?.length) params.party_id = filters.party_id;
+      if (filters.who?.length) params.who = filters.who;
+      if (filters.gender_id?.length) params.gender_id = filters.gender_id;
+      if (filters.chamber_abbrev?.length)
+        params.chamber_abbrev = filters.chamber_abbrev;
+
+      try {
+        const response = await api.get("/tools/kwic/estimate", { params });
+        if (requestId !== this.estimateRequestSequence) return;
+        this.estimatedHits = response.data.estimated_hits;
+        this.inVocabulary = response.data.in_vocabulary;
+      } catch {
+        if (requestId !== this.estimateRequestSequence) return;
+        this.estimatedHits = null;
+        this.inVocabulary = null;
+      }
     },
 
     getKwicResultsPath(search) {
@@ -160,12 +194,14 @@ export const kwicDataStore = defineStore("kwicData", {
           if (data.total_hits != null) {
             this.totalHits = data.total_hits;
           }
-          // Show available rows; ignore failures (more shards may be in flight)
+          // Show available rows for the user's current view; ignore failures
+          // because more shards may still be in flight.
           this.fetchKwicPage({
-            page: 1,
+            page: this.pagination.page,
             rowsPerPage: this.pagination.rowsPerPage,
             sortBy: this.pagination.sortBy,
             descending: this.pagination.descending,
+            silent: true,
           }).catch(() => {});
         }
 
@@ -186,6 +222,7 @@ export const kwicDataStore = defineStore("kwicData", {
       rowsPerPage = this.pagination.rowsPerPage,
       sortBy = this.pagination.sortBy,
       descending = this.pagination.descending,
+      silent = false,
     } = {}) {
       if (!this.ticketId) {
         return null;
@@ -193,7 +230,9 @@ export const kwicDataStore = defineStore("kwicData", {
 
       const requestId = this.requestSequence;
       const pageRequestId = ++this.pageRequestSequence;
-      this.isPageLoading = true;
+      if (!silent) {
+        this.isPageLoading = true;
+      }
 
       try {
         const params = {
@@ -218,7 +257,13 @@ export const kwicDataStore = defineStore("kwicData", {
             return null;
           }
 
-          return this.fetchKwicPage({ page, rowsPerPage, sortBy, descending });
+          return this.fetchKwicPage({
+            page,
+            rowsPerPage,
+            sortBy,
+            descending,
+            silent,
+          });
         }
 
         if (
@@ -258,7 +303,7 @@ export const kwicDataStore = defineStore("kwicData", {
         console.error("Error fetching KWIC page:", error);
         return null;
       } finally {
-        if (pageRequestId === this.pageRequestSequence) {
+        if (!silent && pageRequestId === this.pageRequestSequence) {
           this.isPageLoading = false;
         }
       }

--- a/src/stores/kwicDataStore.js
+++ b/src/stores/kwicDataStore.js
@@ -54,6 +54,9 @@ export const kwicDataStore = defineStore("kwicData", {
     archiveRetrievalUrl: null,
     isLoading: false,
     isPageLoading: false,
+    shardsComplete: 0,
+    shardsTotal: 0,
+    isPartial: false,
     requestSequence: 0,
     pageRequestSequence: 0,
     pagination: {
@@ -93,6 +96,9 @@ export const kwicDataStore = defineStore("kwicData", {
       this.totalPages = 0;
       this.expiresAt = null;
       this.archiveRetrievalUrl = null;
+      this.shardsComplete = 0;
+      this.shardsTotal = 0;
+      this.isPartial = false;
       this.pagination = {
         ...this.pagination,
         page: 1,
@@ -133,16 +139,34 @@ export const kwicDataStore = defineStore("kwicData", {
           return false;
         }
 
-        this.expiresAt = response.data.expires_at;
+        const data = response.data;
+        this.expiresAt = data.expires_at;
 
-        if (response.data.status === "ready") {
+        if (data.status === "ready") {
+          this.isPartial = false;
+          this.shardsComplete = data.shards_complete ?? this.shardsTotal;
+          this.shardsTotal = data.shards_total ?? this.shardsTotal;
           return true;
         }
 
-        if (response.data.status === "error") {
-          throw new Error(
-            response.data.error || i18n.accessibility.kwicQueryFailed,
-          );
+        if (data.status === "error") {
+          throw new Error(data.error || i18n.accessibility.kwicQueryFailed);
+        }
+
+        if (data.status === "partial") {
+          this.isPartial = true;
+          this.shardsComplete = data.shards_complete ?? this.shardsComplete;
+          this.shardsTotal = data.shards_total ?? this.shardsTotal;
+          if (data.total_hits != null) {
+            this.totalHits = data.total_hits;
+          }
+          // Show available rows; ignore failures (more shards may be in flight)
+          this.fetchKwicPage({
+            page: 1,
+            rowsPerPage: this.pagination.rowsPerPage,
+            sortBy: this.pagination.sortBy,
+            descending: this.pagination.descending,
+          }).catch(() => {});
         }
 
         const delayMs = getTicketPollDelayMs(
@@ -204,20 +228,24 @@ export const kwicDataStore = defineStore("kwicData", {
           return null;
         }
 
-        this.kwicData = response.data.kwic_list;
-        this.totalHits = response.data.total_hits;
-        this.totalPages = response.data.total_pages;
-        this.expiresAt = response.data.expires_at;
+        const pageData = response.data;
+        this.kwicData = pageData.kwic_list;
+        this.totalHits = pageData.total_hits;
+        this.totalPages = pageData.total_pages;
+        this.expiresAt = pageData.expires_at;
+        this.isPartial = pageData.status === "partial";
+        this.shardsComplete = pageData.shards_complete ?? this.shardsComplete;
+        this.shardsTotal = pageData.shards_total ?? this.shardsTotal;
         this.pagination = {
           ...this.pagination,
           page,
           rowsPerPage,
           sortBy,
           descending,
-          rowsNumber: response.data.total_hits,
+          rowsNumber: pageData.total_hits,
         };
 
-        return response.data;
+        return pageData;
       } catch (error) {
         if (error.response?.status === 404) {
           this.errorMessage = i18n.accessibility.ticketExpired;

--- a/src/stores/kwicDataStore.js
+++ b/src/stores/kwicDataStore.js
@@ -28,6 +28,7 @@ export const kwicDataStore = defineStore("kwicData", {
   state: () => ({
     wordsLeft: 5,
     wordsRight: 5,
+    cutOff: 100000,
     kwicData: [],
     searchText: "",
     columnNames: {
@@ -53,12 +54,7 @@ export const kwicDataStore = defineStore("kwicData", {
     archiveRetrievalUrl: null,
     isLoading: false,
     isPageLoading: false,
-    estimatedHits: null,
-    inVocabulary: null,
-    displayLimited: false,
-    displayLimit: null,
     requestSequence: 0,
-    estimateRequestSequence: 0,
     pageRequestSequence: 0,
     pagination: {
       sortBy: DEFAULT_SORT_BY,
@@ -97,8 +93,6 @@ export const kwicDataStore = defineStore("kwicData", {
       this.totalPages = 0;
       this.expiresAt = null;
       this.archiveRetrievalUrl = null;
-      this.displayLimited = false;
-      this.displayLimit = null;
       this.pagination = {
         ...this.pagination,
         page: 1,
@@ -112,39 +106,9 @@ export const kwicDataStore = defineStore("kwicData", {
         lemmatized: this.lemmatizeSearch,
         words_before: this.wordsLeft,
         words_after: this.wordsRight,
+        cut_off: this.cutOff,
         filters: metaDataStore().getSelectedKwicTicketFilters(),
       };
-    },
-
-    async fetchEstimate(word) {
-      if (!word || !word.trim()) {
-        this.estimatedHits = null;
-        this.inVocabulary = null;
-        return;
-      }
-
-      const requestId = ++this.estimateRequestSequence;
-      const filters = metaDataStore().getSelectedKwicTicketFilters();
-      const params = { word: word.trim() };
-
-      if (filters.from_year != null) params.from_year = filters.from_year;
-      if (filters.to_year != null) params.to_year = filters.to_year;
-      if (filters.party_id?.length) params.party_id = filters.party_id;
-      if (filters.who?.length) params.who = filters.who;
-      if (filters.gender_id?.length) params.gender_id = filters.gender_id;
-      if (filters.chamber_abbrev?.length)
-        params.chamber_abbrev = filters.chamber_abbrev;
-
-      try {
-        const response = await api.get("/tools/kwic/estimate", { params });
-        if (requestId !== this.estimateRequestSequence) return;
-        this.estimatedHits = response.data.estimated_hits;
-        this.inVocabulary = response.data.in_vocabulary;
-      } catch {
-        if (requestId !== this.estimateRequestSequence) return;
-        this.estimatedHits = null;
-        this.inVocabulary = null;
-      }
     },
 
     getKwicResultsPath(search) {
@@ -243,8 +207,6 @@ export const kwicDataStore = defineStore("kwicData", {
         this.kwicData = response.data.kwic_list;
         this.totalHits = response.data.total_hits;
         this.totalPages = response.data.total_pages;
-        this.displayLimited = response.data.display_limited ?? false;
-        this.displayLimit = response.data.display_limit ?? null;
         this.expiresAt = response.data.expires_at;
         this.pagination = {
           ...this.pagination,
@@ -252,10 +214,7 @@ export const kwicDataStore = defineStore("kwicData", {
           rowsPerPage,
           sortBy,
           descending,
-          rowsNumber:
-            response.data.display_limited && response.data.display_limit != null
-              ? Math.min(response.data.total_hits, response.data.display_limit)
-              : response.data.total_hits,
+          rowsNumber: response.data.total_hits,
         };
 
         return response.data;
@@ -287,6 +246,7 @@ export const kwicDataStore = defineStore("kwicData", {
           words_before: this.wordsLeft,
           words_after: this.wordsRight,
           lemmatized: this.lemmatizeSearch,
+          ...(this.cutOff !== null && { cut_off: this.cutOff }),
         };
 
         const queryString = metaDataStore().getSelectedParams(additionalParams);


### PR DESCRIPTION
## Summary

Implements the frontend half of progressive shard delivery for KWIC search results, so users see partial results as they arrive from the backend rather than waiting for the full query to complete.

## Changes

### `src/stores/kwicDataStore.js`
- Added `shardsComplete`, `shardsTotal`, and `isPartial` state fields.
- Updated the `waitForTicketReady` poll loop to continue polling on `partial` status and fire `fetchKwicPage` on each partial update so rows appear incrementally.
- Updated `fetchKwicPage` to sync shard progress state from the page response.

### `src/components/kwicDataTable.vue`
- Added a `q-linear-progress` shard progress bar that is shown during `PARTIAL` status.
- Disabled column sort changes while the result is still partial (`onRequest` guard).
- Removed the unused result-count estimate display that was replaced by the real total once results are ready.

### `src/i18n/en-US/index.js` & `src/i18n/sv/index.js`
- Added translation key for the shard progress label.
- Removed stale estimate-related translation keys.

## Related

Backend counterpart: `humlab-swedeb/swedeb-api` branch `kwic-progressive-load` (adds `PARTIAL` ticket status, shard storage, and the multiprocess callback API).
