### PR TITLE
fix(kwic): remove hard-coded cutOff that capped results to 800k rows

### DIFF
--- a/src/stores/kwicDataStore.js
+++ b/src/stores/kwicDataStore.js
@@ -28,7 +28,7 @@ export const kwicDataStore = defineStore("kwicData", {
   state: () => ({
     wordsLeft: 5,
     wordsRight: 5,
-    cutOff: 100000,
+    cutOff: null,
     kwicData: [],
     searchText: "",
     columnNames: {


### PR DESCRIPTION
cutOff: 100000 was sent as cut_off per request, applied per shard in the backend. With 8 shards this limited results to 8 × 100k = 800k instead of the intended global cap of 500k from backend config.

Set cutOff: null so buildKwicTicketPayload omits the field entirely, letting the backend kwic.cut_off config value (500 000) govern.

Closes #209