### PR TITLE
feat(kwic): update estimated hits when filters change

### DIFF
--- a/src/components/toolsFilterData/searchBar.vue
+++ b/src/components/toolsFilterData/searchBar.vue
@@ -84,6 +84,22 @@ watch(
   },
 );
 
+watch(
+  () => metaStore.getSelectedKwicTicketFilters(),
+  () => {
+    if (route.path !== "/tools/kwic") return;
+    const word = kwicStore.searchText;
+    if (!word || !word.trim()) return;
+    clearTimeout(estimateDebounceTimer);
+    estimateDebounceTimer = setTimeout(() => {
+      if (route.path === "/tools/kwic") {
+        kwicStore.fetchEstimate(word);
+      }
+    }, 400);
+  },
+  { deep: true },
+);
+
 onBeforeUnmount(() => {
   clearTimeout(estimateDebounceTimer);
 });


### PR DESCRIPTION
Add a watcher on metaStore.getSelectedKwicTicketFilters() so that changing year, party, gender, chamber, or speaker filters re-triggers fetchEstimate with the current search word (400 ms debounce).

Closes #211