### PR TITLE
fix(expandingTableRow): fix PDF viewer link for history routing mode

### DIFF
--- a/src/components/expandingTableRow.vue
+++ b/src/components/expandingTableRow.vue
@@ -242,11 +242,7 @@ const openPdf = () => {
   pdfStore.setRowData(data);
   sessionStorage.setItem("pdfData", JSON.stringify(data));
   const clientRoutePath = isPagePdfSource(props.props.row.source) ? "/pdf-pagewise" : "/pdf";
-  const clientRouteHash = `#${clientRoutePath}`;
-  const spaPublicPath = '/public/';
-  const fullPathToIndexHtml = `${window.location.origin}${spaPublicPath}index.html`;
-  const finalUrlToOpen = `${fullPathToIndexHtml}${clientRouteHash}`;
-  window.open(finalUrlToOpen, "_blank");
+  window.open(clientRoutePath, "_blank");
 };
 
 const replaceNewLine = (str) => {

--- a/src/i18n/sv/index.js
+++ b/src/i18n/sv/index.js
@@ -266,17 +266,17 @@ export default {
   financiers: {
     0: {
       alt: "Umeå universitet logo",
-      src: "/public/images/umu-logo-left-SE.png",
+      src: "/images/umu-logo-left-SE.png",
       style: "width: 200px",
     },
     1: {
       alt: "Humlab logo",
-      src: "/public/images/humlab_logo_left_se.png",
+      src: "/images/humlab_logo_left_se.png",
       style: "width: 250px",
     },
     2: {
       alt: "Huminfra logo",
-      src: "/public/images/HumInfra_3_b.png",
+      src: "/images/HumInfra_3_b.png",
       style: "width: 150px",
     },
   },
@@ -394,7 +394,7 @@ export default {
       under 1800-talet) finns under kategorin ”Utan partibeteckning”. Det gör även flera
       ledamöter som hoppat av ett parti under mandatperioden.
 
-      <img src="/public/images/parti.png" alt="Partiutveckling" style="width: 100%; margin-top: 20px;" />
+      <img src="/images/parti.png" alt="Partiutveckling" style="width: 100%; margin-top: 20px;" />
 
 </br></br>
       Det är viktigt att känna till att ett parti på 1800-talet inte är samma sak som


### PR DESCRIPTION
openPdf was constructing a hash-mode URL (origin/public/index.html#/pdf) which resolves to the home page under history routing. Replace with a direct window.open('/pdf', '_blank') — the server/nginx handles the SPA and the router takes over from there.

Closes #214, #213