### PR TITLE
Pdf pages

### DIFF
--- a/src/pages/PdfPageWise.vue
+++ b/src/pages/PdfPageWise.vue
@@ -247,16 +247,14 @@ const persistPdfData = () => {
 };
 
 const loadPageRange = async (protocolName) => {
+  lastPage.value = await pdfStore.loadPageRange(protocolName);
 
-      lastPage.value = await pdfStore.loadPageRange(protocolName);
-
-      if (lastPage.value === null){
-        lastPage.value = page.value;
-      }
-      if (lastPage.value == 1 && fourDigitYear.value) {
-        lastPage.value = TMP_LAST_PAGE; // temp adjustment for protocols from four digit-years without range
-      }
-
+  if (lastPage.value === null) {
+    lastPage.value = page.value;
+  }
+  if (lastPage.value == 1 && fourDigitYear.value) {
+    lastPage.value = TMP_LAST_PAGE; // temp adjustment for protocols from four digit-years without range
+  }
 };
 
 const setPage = (nextPage) => {
@@ -326,11 +324,14 @@ onMounted(async () => {
 
   checkFourDigitYear(pdfSrc.value);
 
+  // To adjust for zero-indexing of pdf-files
   page.value =
-    !fourDigitYear.value && parsed.page >= 1 ? parsed.page - 1 : parsed.page; // To adjust for zero-indexing of pdf-files
+    !fourDigitYear.value && parsed.page >= 1 ? parsed.page - 1 : parsed.page;
+
+  // setting page in pdf link to mitigate issue with the link always being for page 1 for WT
+  setPage(page.value);
 
   lastPage.value = page.value;
-
   if (pagePdfInfo?.protocolName) {
     await loadPageRange(pagePdfInfo.protocolName);
   }

--- a/src/pages/PdfPageWise.vue
+++ b/src/pages/PdfPageWise.vue
@@ -8,7 +8,9 @@
     :class="$q.screen.lt.md ? '' : 'row justify-center q-px-xl'"
   >
     <q-card-section :class="$q.screen.lt.md ? 'q-pa-none' : 'col-7'">
-      <q-card-section class="row justify-center justify-between q-py-none full-width">
+      <q-card-section
+        class="row justify-center justify-between q-py-none full-width"
+      >
         <q-card-section class="q-pt-none">
           <q-btn
             class="q-mr-md q-pl-sm"
@@ -16,7 +18,7 @@
             no-caps
             @click="prevPage"
             icon="chevron_left"
-            :disable="page <= firstPage"
+            :disable="page <= 1"
           >
             {{ $t("previousPage") }}
           </q-btn>
@@ -35,11 +37,17 @@
           </q-btn>
         </q-card-section>
         <q-card-section class="q-pa-none">
-          <q-btn no-caps flat @click="zoomIn" icon="zoom_in">{{ $t("zoomIn") }}</q-btn>
-          <q-btn no-caps flat @click="zoomOut" icon="zoom_out">{{ $t("zoomOut") }}</q-btn>
+          <q-btn no-caps flat @click="zoomIn" icon="zoom_in">{{
+            $t("zoomIn")
+          }}</q-btn>
+          <q-btn no-caps flat @click="zoomOut" icon="zoom_out">{{
+            $t("zoomOut")
+          }}</q-btn>
         </q-card-section>
       </q-card-section>
-      <div class="q-ml-md q-pr-sm text-bold text-negative">{{ $t("pageNrInfoText") }}</div>
+      <div class="q-ml-md q-pr-sm text-bold text-negative">
+        {{ $t("pageNrInfoText") }}
+      </div>
       <q-separator size="2px" color="grey-5" />
       <q-card-section class="pdf-viewport bg-white q-ma-none">
         <div v-if="pdfSrc" class="pdf-inner">
@@ -75,7 +83,11 @@
               <q-item-label
                 v-if="speakerData.speaker"
                 class="q-mt-xs"
-                :class="speakerData.speaker === 'Okänd' ? 'text-italic text-grey-6' : ''"
+                :class="
+                  speakerData.speaker === 'Okänd'
+                    ? 'text-italic text-grey-6'
+                    : ''
+                "
               >
                 {{
                   speakerData.speaker === "Okänd"
@@ -86,7 +98,9 @@
               <q-item-label
                 v-if="speakerData.party"
                 class="q-mt-xs"
-                :class="speakerData.party === '[-]' ? 'text-italic text-grey-6' : ''"
+                :class="
+                  speakerData.party === '[-]' ? 'text-italic text-grey-6' : ''
+                "
               >
                 ({{
                   speakerData.party === "[-]"
@@ -97,7 +111,11 @@
               <q-item-label
                 v-if="speakerData.gender"
                 class="q-mt-xs"
-                :class="speakerData.gender === 'Okänt' ? 'text-italic text-grey-6' : ''"
+                :class="
+                  speakerData.gender === 'Okänt'
+                    ? 'text-italic text-grey-6'
+                    : ''
+                "
               >
                 {{
                   speakerData.gender === "Okänt"
@@ -106,7 +124,9 @@
                 }}
               </q-item-label>
             </div>
-            <q-item-label caption class="text-bold">{{ speakerData.protocol }}</q-item-label>
+            <q-item-label caption class="text-bold">{{
+              speakerData.protocol
+            }}</q-item-label>
             <q-item-label class="q-pt-xs" v-if="speakerData.node_word">
               {{ $t("searchWordLabel") }}
               <b>{{ speakerData.node_word }}</b>
@@ -138,7 +158,8 @@ import { api } from "boot/axios";
 import { metaDataStore } from "src/stores/metaDataStore";
 import { pdfDataStore } from "src/stores/pdfDataStore";
 
-const PAGE_PDF_PATH_RE = /\/(?<year>\d{4,8})\/(?<protocol>prot-[^/]+)\/(?<filename>prot-[^/]+)_(?<page>\d+)\.pdf$/;
+const PAGE_PDF_PATH_RE =
+  /\/(?<year>\d{4,8})\/(?<protocol>prot-[^/]+)\/(?<filename>prot-[^/]+)_(?<page>\d+)\.pdf$/;
 
 const pdfStore = pdfDataStore();
 const metaStore = metaDataStore();
@@ -147,7 +168,6 @@ const speakerData = ref({});
 const speechText = ref("");
 const speakerNote = ref("");
 const page = ref(1);
-const firstPage = ref(1);
 const lastPage = ref(1);
 const pdfSrc = ref(null);
 const docWidth = ref(600);
@@ -213,12 +233,10 @@ const loadPageRange = async (protocolName) => {
     });
 
     if (Array.isArray(response.data) && response.data.length === 2) {
-      firstPage.value = Number(response.data[0]);
       lastPage.value = Number(response.data[1]);
     }
   } catch (error) {
     console.error("Error fetching protocol page range:", error);
-    firstPage.value = page.value;
     lastPage.value = page.value;
   }
 };
@@ -240,7 +258,7 @@ const nextPage = () => {
 };
 
 const prevPage = () => {
-  if (page.value > firstPage.value) {
+  if (page.value > 1) {
     setPage(page.value - 1);
   }
 };
@@ -274,8 +292,7 @@ onMounted(async () => {
   pdfSrc.value = parsed.speakerData?.source ?? null;
 
   const pagePdfInfo = parsePagePdfSource(pdfSrc.value);
-  page.value = pagePdfInfo?.page ?? Number(parsed.page ?? 1);
-  firstPage.value = page.value;
+  page.value = parsed.page - 1; // To adjust for zero-indexing of pdf-files
   lastPage.value = page.value;
 
   if (pagePdfInfo?.protocolName) {

--- a/src/pages/PdfPageWise.vue
+++ b/src/pages/PdfPageWise.vue
@@ -51,7 +51,7 @@
       <q-separator size="2px" color="grey-5" />
       <q-card-section class="pdf-viewport bg-white q-ma-none">
         <div v-if="pdfSrc" class="pdf-inner">
-          <PdfEmbed :key="pdfSrc" :source="pdfSrc" :width="docWidth" />
+          <PdfEmbed :key="pdfSrc" :source="pdfSrc" :width="docWidth" @loading-failed="handleLoadingFail"/>
         </div>
         <div v-else>
           <p>PDF is not available.</p>
@@ -174,6 +174,7 @@ const lastPage = ref(1);
 const pdfSrc = ref(null);
 const docWidth = ref(600);
 const fourDigitYear = ref(false);
+const fallBackToFirstPage = ref(true)
 
 const getDisplayPageNbr = () => {
   if (fourDigitYear.value) {
@@ -181,6 +182,16 @@ const getDisplayPageNbr = () => {
   }
   return page.value + 1;
 };
+
+const handleLoadingFail = () => {
+  //If page not loadable from server
+  //display first page unless next page requested
+  if (fallBackToFirstPage.value){
+    setPage(0);
+    console.log(pdfSrc.value)
+  }
+
+}
 
 const checkFourDigitYear = (source) => {
   YEARS_WITH_FOUR_DIGIT_PAGES.forEach((year, _) => {
@@ -282,6 +293,7 @@ const nextPageExists = () => {
 };
 
 const nextPage = () => {
+  fallBackToFirstPage.value = false;
   if (nextPageExists()) {
     setPage(page.value + 1);
   }
@@ -308,6 +320,7 @@ const goBack = () => {
 };
 
 onMounted(async () => {
+  fallBackToFirstPage.value = true;
   const storedData = sessionStorage.getItem("pdfData");
   if (!storedData) {
     return;
@@ -337,6 +350,7 @@ onMounted(async () => {
   }
 
   persistPdfData();
+
 });
 </script>
 

--- a/src/pages/PdfPageWise.vue
+++ b/src/pages/PdfPageWise.vue
@@ -18,12 +18,12 @@
             no-caps
             @click="prevPage"
             icon="chevron_left"
-            :disable="page <= 0"
+            :disable="!previousPageExists()"
           >
             {{ $t("previousPage") }}
           </q-btn>
           <span class="text-bold text-subtitle1">
-            {{ page + 1}} / {{ lastPage }} 
+            {{ getDisplayPageNbr() }} / {{ lastPage }}
           </span>
           <q-btn
             class="q-ml-md q-pr-sm"
@@ -31,7 +31,7 @@
             no-caps
             icon-right="chevron_right"
             @click="nextPage"
-            :disable="page >= lastPage"
+            :disable="!nextPageExists()"
           >
             {{ $t("nextPage") }}
           </q-btn>
@@ -158,6 +158,9 @@ import { api } from "boot/axios";
 import { metaDataStore } from "src/stores/metaDataStore";
 import { pdfDataStore } from "src/stores/pdfDataStore";
 
+const YEARS_WITH_FOUR_DIGIT_PAGES = ["199091", "199192", "199293", "199394"];
+const TMP_FIRST_PAGE = 1;
+const TMP_LAST_PAGE = 200;
 const PAGE_PDF_PATH_RE =
   /\/(?<year>\d{4,8})\/(?<protocol>prot-[^/]+)\/(?<filename>prot-[^/]+)_(?<page>\d+)\.pdf$/;
 
@@ -171,6 +174,22 @@ const page = ref(1);
 const lastPage = ref(1);
 const pdfSrc = ref(null);
 const docWidth = ref(600);
+const fourDigitYear = ref(false);
+
+const getDisplayPageNbr = () => {
+  if (fourDigitYear.value) {
+    return page.value;
+  }
+  return page.value + 1;
+};
+
+const checkFourDigitYear = (source) => {
+  YEARS_WITH_FOUR_DIGIT_PAGES.forEach((year, _) => {
+    if (source.indexOf(year) !== -1) {
+      fourDigitYear.value = true;
+    }
+  });
+};
 
 const parsePagePdfSource = (source) => {
   if (!source) {
@@ -200,10 +219,13 @@ const parsePagePdfSource = (source) => {
 };
 
 const replacePageNumberInSource = (source, nextPage) => {
-  const paddedPage = String(nextPage).padStart(3, "0");
+  const padLen = fourDigitYear.value ? 4 : 3;
+  const paddedPage = String(nextPage).padStart(padLen, "0");
 
   try {
     const url = new URL(source);
+    parsed = parsePagePdfSource(source);
+
     url.pathname = url.pathname.replace(/_\d+\.pdf$/, `_${paddedPage}.pdf`);
     return url.toString();
   } catch (error) {
@@ -232,8 +254,12 @@ const loadPageRange = async (protocolName) => {
       params: { protocol_name: protocolName },
     });
 
+
     if (Array.isArray(response.data) && response.data.length === 2) {
       lastPage.value = Number(response.data[1]);
+      if (lastPage.value == 1 && fourDigitYear.value) {
+        lastPage.value = TMP_LAST_PAGE; // temp adjustment for protocols from four digit-years without range
+      }
     }
   } catch (error) {
     console.error("Error fetching protocol page range:", error);
@@ -251,14 +277,28 @@ const setPage = (nextPage) => {
   persistPdfData();
 };
 
+const previousPageExists = () => {
+  if (fourDigitYear.value) {
+    return page.value > TMP_FIRST_PAGE;
+  }
+  return page.value >= TMP_FIRST_PAGE;
+};
+
+const nextPageExists = () => {
+  return (
+    (page.value < lastPage.value - 1 && !fourDigitYear.value) ||
+    (page.value < lastPage.value && fourDigitYear.value)
+  );
+};
+
 const nextPage = () => {
-  if (page.value < lastPage.value) {
+  if (nextPageExists()) {
     setPage(page.value + 1);
   }
 };
 
 const prevPage = () => {
-  if (page.value >= 1) {
+  if (previousPageExists()) {
     setPage(page.value - 1);
   }
 };
@@ -292,7 +332,11 @@ onMounted(async () => {
   pdfSrc.value = parsed.speakerData?.source ?? null;
 
   const pagePdfInfo = parsePagePdfSource(pdfSrc.value);
-  page.value = parsed.page >= 1 ? parsed.page - 1 : parsed.page; // To adjust for zero-indexing of pdf-files
+
+  checkFourDigitYear(pdfSrc.value);
+
+  page.value =
+    !fourDigitYear.value && parsed.page >= 1 ? parsed.page - 1 : parsed.page; // To adjust for zero-indexing of pdf-files
 
   lastPage.value = page.value;
 

--- a/src/pages/PdfPageWise.vue
+++ b/src/pages/PdfPageWise.vue
@@ -244,27 +244,20 @@ const persistPdfData = () => {
     page: page.value,
   };
 
-  pdfStore.setRowData(data);
   sessionStorage.setItem("pdfData", JSON.stringify(data));
 };
 
 const loadPageRange = async (protocolName) => {
-  try {
-    const response = await api.get("/tools/protocol/page_range", {
-      params: { protocol_name: protocolName },
-    });
 
+      lastPage.value = await pdfStore.loadPageRange(protocolName);
 
-    if (Array.isArray(response.data) && response.data.length === 2) {
-      lastPage.value = Number(response.data[1]);
+      if (lastPage.value === null){
+        lastPage.value = page.value;
+      }
       if (lastPage.value == 1 && fourDigitYear.value) {
         lastPage.value = TMP_LAST_PAGE; // temp adjustment for protocols from four digit-years without range
       }
-    }
-  } catch (error) {
-    console.error("Error fetching protocol page range:", error);
-    lastPage.value = page.value;
-  }
+
 };
 
 const setPage = (nextPage) => {
@@ -324,7 +317,6 @@ onMounted(async () => {
   }
 
   const parsed = JSON.parse(storedData);
-  pdfStore.setRowData(parsed);
 
   speakerData.value = parsed.speakerData ?? {};
   speechText.value = parsed.speechText ?? "";

--- a/src/pages/PdfPageWise.vue
+++ b/src/pages/PdfPageWise.vue
@@ -154,7 +154,6 @@
 import { onMounted, ref } from "vue";
 import PdfEmbed from "vue-pdf-embed";
 
-import { api } from "boot/axios";
 import { metaDataStore } from "src/stores/metaDataStore";
 import { pdfDataStore } from "src/stores/pdfDataStore";
 

--- a/src/pages/PdfPageWise.vue
+++ b/src/pages/PdfPageWise.vue
@@ -18,12 +18,12 @@
             no-caps
             @click="prevPage"
             icon="chevron_left"
-            :disable="page <= 1"
+            :disable="page <= 0"
           >
             {{ $t("previousPage") }}
           </q-btn>
           <span class="text-bold text-subtitle1">
-            {{ page }} / {{ lastPage }}
+            {{ page + 1}} / {{ lastPage }} 
           </span>
           <q-btn
             class="q-ml-md q-pr-sm"
@@ -258,7 +258,7 @@ const nextPage = () => {
 };
 
 const prevPage = () => {
-  if (page.value > 1) {
+  if (page.value >= 1) {
     setPage(page.value - 1);
   }
 };
@@ -292,7 +292,8 @@ onMounted(async () => {
   pdfSrc.value = parsed.speakerData?.source ?? null;
 
   const pagePdfInfo = parsePagePdfSource(pdfSrc.value);
-  page.value = parsed.page - 1; // To adjust for zero-indexing of pdf-files
+  page.value = parsed.page >= 1 ? parsed.page - 1 : parsed.page; // To adjust for zero-indexing of pdf-files
+
   lastPage.value = page.value;
 
   if (pagePdfInfo?.protocolName) {

--- a/src/stores/pdfDataStore.js
+++ b/src/stores/pdfDataStore.js
@@ -1,4 +1,5 @@
 import { defineStore } from "pinia";
+import { api } from "boot/axios";
 
 export const pdfDataStore = defineStore("pdfStore", {
   state: () => ({
@@ -7,6 +8,21 @@ export const pdfDataStore = defineStore("pdfStore", {
   actions: {
     setRowData(data) {
       this.speechData = data;
+    },
+
+    async loadPageRange(protocolName) {
+      try {
+        const response = await api.get("/tools/protocol/page_range", {
+          params: { protocol_name: protocolName },
+        });
+
+        if (Array.isArray(response.data) && response.data.length === 2) {
+          return Number(response.data[1]);
+        }
+      } catch (error) {
+        console.error("Error fetching protocol page range:", error);
+        return null;
+      }
     },
   },
 });


### PR DESCRIPTION
Updates to Page wise pdf-viewer

Some assumptions:

- All pdf page ranges start with page 1 (disregarding other information where the first page is often 2 or 3 making it impossible to go back to the first page of the protocol)
- pdf-pages are numbered from 000 (0001 for years with four digits for representing pages). Displayed pdf-page is adjusted so that page 1 displays page 000 etc for three-digit years
- If a protocol has no range (mainly for the years with four digits) the range is assumed to be 1, 200
- If a pdf is not found on the server onMount, the requested page is probably outside of the true range of pages. In that case, the first page (000/0001) of the protocol is displayed
- If the range is larger than the true range, it is possible to click "next page" until end of the range. Blank pages are displayed and the user can typically see when the protocol actually ends
- api info on page is considered more reliable than page suffix in pdf link (mainly relevant for word trends) and is therefore used
